### PR TITLE
feat: separate iOS beta app for dev builds (org.mieweb.os.dev)

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -244,6 +244,11 @@ jobs:
       - name: Generate build info
         run: node generate-build-info.js
 
+      - name: Generate beta icons
+        run: |
+          pip3 install Pillow
+          python3 generate_app_resources.py public/resources/icon-beta.png
+
       # Dev Android uses 'com.mieweb.mieauth.dev' to separate from production
       - name: Patch mobile-config.js for Dev Android bundle ID
         run: |
@@ -353,6 +358,11 @@ jobs:
 
       - name: Generate build info
         run: node generate-build-info.js
+
+      - name: Generate beta icons
+        run: |
+          pip3 install Pillow
+          python3 generate_app_resources.py public/resources/icon-beta.png
 
       # Dev iOS uses 'org.mieweb.os.dev' to separate from production
       - name: Patch mobile-config.js for Dev iOS bundle ID & app name


### PR DESCRIPTION
feat: separate iOS beta app for dev builds (org.mieweb.os.dev)

- Patch iOS bundle ID to org.mieweb.os.dev and name to MIEAuth (Opensource) (Beta)
- Use dedicated dev secrets for iOS provisioning profile and Firebase plist
- Generate beta icons from icon-beta.png for both Android and iOS dev builds
- Fix release body to show correct bundle IDs