### PR TITLE
fix(ci): pass secrets via env vars to prevent shell escaping in Fastlane

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -338,8 +338,10 @@ jobs:
       - name: Decode Keystore
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > mieauth-release-key.jks
 
-      - name: Sign and publish Android AAB with Fastlane
+      - name: Sign and upload Android with Fastlane
         env:
+          ANDROID_KS_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KS_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           SAFE_VERSION=$(echo "${APP_VERSION}" | tr '()' '..')
@@ -350,8 +352,8 @@ jobs:
             aab_search_root:"android-build" \
             output_aab_path:"${SIGNED_AAB}" \
             keystore_path:"mieauth-release-key.jks" \
-            keystore_password:"${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            key_password:"${{ secrets.ANDROID_KEY_PASSWORD }}" \
+            keystore_password:"$ANDROID_KS_PASSWORD" \
+            key_password:"$ANDROID_KS_KEY_PASSWORD" \
             keystore_alias:"${{ secrets.ANDROID_KEYSTORE_ALIAS }}" \
             package_name:"org.mieweb.os.dev" \
             version_name:"MIEAuth Dev v${APP_VERSION}" \
@@ -448,14 +450,34 @@ jobs:
           mkdir -p ~/private_keys
           echo "${{ secrets.APPLE_API_KEY_P8_BASE64 }}" | base64 --decode > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
 
+      - name: Validate iOS signing certificate
+        env:
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+        run: |
+          echo "Validating .p12 certificate file..."
+          file_size=$(wc -c < "$RUNNER_TEMP/certificate.p12" | tr -d ' ')
+          echo "Certificate file size: ${file_size} bytes"
+          if [ "$file_size" -lt 100 ]; then
+            echo "::error::Certificate file is too small (${file_size} bytes). Check IOS_DIST_CERT_P12_BASE64 secret."
+            exit 1
+          fi
+          openssl pkcs12 -in "$RUNNER_TEMP/certificate.p12" -passin pass:"$IOS_CERTIFICATE_PASSWORD" -nokeys -noout 2>&1 || {
+            echo "::error::Failed to read .p12 certificate. Either IOS_DIST_CERT_PASSWORD is wrong or the .p12 file is corrupted/incompatible."
+            echo "If the .p12 was exported with OpenSSL 3.x, try re-exporting with the -legacy flag."
+            exit 1
+          }
+          echo "Certificate validated successfully."
+
       - name: Archive and upload iOS with Fastlane
+        env:
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
         run: |
           bundle exec fastlane ios publish_dev \
             workspace_root:"ios-build" \
             team_id:"${{ secrets.APPLE_TEAM_ID }}" \
             bundle_id:"org.mieweb.os.dev" \
             certificate_path:"$RUNNER_TEMP/certificate.p12" \
-            certificate_password:"${{ secrets.IOS_DIST_CERT_PASSWORD }}" \
+            certificate_password:"$IOS_CERTIFICATE_PASSWORD" \
             provisioning_profile_path:"$RUNNER_TEMP/profile.mobileprovision" \
             api_key_id:"${{ secrets.APPLE_API_KEY_ID }}" \
             api_issuer_id:"${{ secrets.APPLE_API_ISSUER_ID }}" \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,25 @@ def provisioning_profile_name(profile_path)
   match[1]
 end
 
+def ci_keychain_path
+  path = Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_PATH]
+  return nil if path.nil? || path.empty?
+
+  File.expand_path(path)
+end
+
+def has_distribution_identity?(keychain_path, team_id)
+  return false if keychain_path.nil? || keychain_path.empty?
+
+  identities = sh(
+    "security find-identity -v -p codesigning #{Shellwords.escape(keychain_path)}",
+    log: false,
+    error_callback: proc { |_result| return false }
+  )
+
+  identities.include?("Apple Distribution") && identities.include?("(#{team_id})")
+end
+
 platform :android do
   desc "Sign and publish Android AAB to Google Play"
   lane :publish_dev do |options|
@@ -140,6 +159,7 @@ platform :ios do
     setup_ci if ENV["CI"]
     keychain_name = ENV["MATCH_KEYCHAIN_NAME"]
     keychain_password = ENV["MATCH_KEYCHAIN_PASSWORD"]
+    keychain_path = ci_keychain_path
 
     import_certificate(
       certificate_path: certificate_path,
@@ -147,6 +167,13 @@ platform :ios do
       keychain_name: keychain_name,
       keychain_password: keychain_password
     )
+
+    unless has_distribution_identity?(keychain_path, team_id)
+      UI.user_error!(
+        "Apple Distribution certificate import failed. Verify IOS_DIST_CERT_P12_BASE64 and IOS_DIST_CERT_PASSWORD. " \
+        "No Apple Distribution identity for team #{team_id} was found in #{keychain_path || keychain_name}."
+      )
+    end
 
     install_provisioning_profile(path: provisioning_profile_path)
 
@@ -168,9 +195,11 @@ platform :ios do
       scheme: scheme,
       configuration: "Release",
       destination: "generic/platform=iOS",
+      codesigning_identity: "Apple Distribution",
       export_method: "app-store",
       export_team_id: team_id,
       export_options: {
+        signingCertificate: "Apple Distribution",
         signingStyle: "manual",
         provisioningProfiles: {
           bundle_id => provisioning_profile
@@ -179,6 +208,8 @@ platform :ios do
       xcargs: [
         "DEVELOPMENT_TEAM=#{team_id}",
         "CODE_SIGN_STYLE=Manual",
+        "CODE_SIGN_IDENTITY=Apple Distribution",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]=Apple Distribution",
         "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(provisioning_profile)}"
       ].join(" ")
     )


### PR DESCRIPTION
The iOS build failed with "MAC verification failed during PKCS12 import (wrong password?)" because the certificate password was expanded inline as a CLI argument. Special characters in the password were mangled by bash before reaching Fastlane.

- Pass iOS cert password and Android keystore passwords through env vars instead of inline ${{ secrets.* }} expansion in CLI args
- Add pre-flight validation step that verifies the .p12 can be read before invoking Fastlane, for faster failure with a clear message
- Add ci_keychain_path and has_distribution_identity? helpers to Fastfile to detect and report certificate import failures early
- Set explicit CODE_SIGN_IDENTITY and codesigning_identity for the iOS archive step