### PR TITLE
fix(ios): import signing cert directly, bypass match PKCS12 on macOS 15

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -445,26 +445,13 @@ jobs:
           mkdir -p ~/private_keys
           echo "${{ secrets.APPLE_API_KEY_P8_BASE64 }}" | base64 --decode > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
 
-      - name: "DEBUG: CI signing environment"
+      - name: Decode distribution certificate
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
         run: |
-          echo "=== OpenSSL versions ==="
-          which openssl
-          openssl version
-          /usr/bin/openssl version 2>/dev/null || true
-          ruby -ropenssl -e 'puts "Ruby OpenSSL: #{OpenSSL::OPENSSL_VERSION}"; puts "Ruby OpenSSL lib: #{OpenSSL::OPENSSL_LIBRARY_VERSION}"'
-
-          echo ""
-          echo "=== Keychain state before match ==="
-          security list-keychains
-          security find-identity -v -p codesigning || true
-
-          echo ""
-          echo "=== macOS version ==="
-          sw_vers
-
-          echo ""
-          echo "=== Xcode version ==="
-          xcodebuild -version
+          CERT_PATH="$RUNNER_TEMP/distribution.p12"
+          echo "$IOS_DIST_CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "IOS_DIST_CERT_P12_PATH=$CERT_PATH" >> $GITHUB_ENV
 
       - name: Archive and upload iOS with Fastlane
         env:
@@ -474,6 +461,7 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           MATCH_GIT_URL: ${{ vars.MATCH_GIT_URL }}
           MATCH_GIT_BRANCH: ${{ vars.MATCH_GIT_BRANCH }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
         run: |
           bundle exec fastlane ios publish_dev \
             workspace_root:"ios-build" \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,51 +135,25 @@ def publish_ios(options)
 
   setup_ci if ENV["CI"]
 
-  # ── DEBUG: Pre-match environment ──
-  UI.important("═══ DEBUG: Pre-match diagnostics ═══")
-  UI.message("Ruby OpenSSL version: #{OpenSSL::OPENSSL_VERSION}")
-  UI.message("Ruby OpenSSL library version: #{OpenSSL::OPENSSL_LIBRARY_VERSION}")
-  sh("which openssl", log: false) rescue nil
-  sh("openssl version", log: false) rescue nil
-  sh("security find-identity -v -p codesigning", log: false) rescue nil
-  UI.important("═══ DEBUG: Running match now ═══")
-
   match(
     type: "appstore",
     app_identifier: bundle_id,
     api_key: api_key,
-    verbose: true,
     readonly: ENV["CI"].to_s == "true"
   )
 
-  # ── DEBUG: Post-match diagnostics ──
-  UI.important("═══ DEBUG: Post-match diagnostics ═══")
-
-  # Check keychain identities after match
-  sh("security find-identity -v -p codesigning", log: false) rescue nil
-
-  # Check what keychains are in the search list
-  sh("security list-keychains", log: false) rescue nil
-
-  # Check match environment variables that were set
-  match_env_vars = ENV.select { |k, _| k.start_with?("sigh_") || k.start_with?("MATCH_") }
-  match_env_vars.each do |k, v|
-    # Don't print sensitive values
-    if k.include?("PASSWORD") || k.include?("AUTHORIZATION")
-      UI.message("  #{k} = [REDACTED]")
-    else
-      UI.message("  #{k} = #{v}")
-    end
+  # Import signing certificate with private key directly.
+  # Match handles provisioning profiles fine, but its PKCS12 import
+  # fails on macOS 15 due to empty-password format incompatibility.
+  cert_p12_path = ENV["IOS_DIST_CERT_P12_PATH"]
+  cert_password = ENV["IOS_DIST_CERT_PASSWORD"]
+  if cert_p12_path && !cert_p12_path.empty? && File.exist?(cert_p12_path)
+    import_certificate(
+      certificate_path: cert_p12_path,
+      certificate_password: cert_password || "",
+      keychain_name: "fastlane_tmp_keychain"
+    )
   end
-
-  # Check if match downloaded any certs/profiles
-  match_dir = File.join(Dir.tmpdir, "d*")
-  Dir.glob(match_dir).sort.last(3).each do |d|
-    UI.message("Temp dir: #{d}")
-    Dir.glob(File.join(d, "**", "*")).each { |f| UI.message("  #{f} (#{File.size(f)} bytes)") } rescue nil
-  end
-
-  UI.important("═══ DEBUG: End post-match diagnostics ═══")
 
   provisioning_profiles = Actions.lane_context[Fastlane::Actions::SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}
   provisioning_profile = provisioning_profiles[bundle_id]


### PR DESCRIPTION
Match's empty-password .p12 import fails with 'MAC verification failed' on macOS 15 due to PKCS12 format incompatibility. Keep match for provisioning profiles, use import_certificate with the original password-protected .p12 for the signing identity.

Removes debug logging from previous diagnostic run.