### PR TITLE
fix(ios): use raw security import with exec-style args, bypass shell

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,5 @@
 require "fileutils"
+require "open3"
 require "shellwords"
 require "tmpdir"
 
@@ -144,15 +145,26 @@ def publish_ios(options)
 
   # Import signing certificate with private key directly.
   # Match handles provisioning profiles fine, but its PKCS12 import
-  # fails on macOS 15 due to empty-password format incompatibility.
+  # fails on macOS 15. Fastlane's import_certificate also fails due to
+  # missing -f pkcs12 flag and unsafe password escaping.
+  # Use raw security import with the exact flags from the working production workflow.
   cert_p12_path = ENV["IOS_DIST_CERT_P12_PATH"]
-  cert_password = ENV["IOS_DIST_CERT_PASSWORD"]
+  cert_password = ENV["IOS_DIST_CERT_PASSWORD"] || ""
   if cert_p12_path && !cert_p12_path.empty? && File.exist?(cert_p12_path)
-    import_certificate(
-      certificate_path: cert_p12_path,
-      certificate_password: cert_password || "",
-      keychain_name: "fastlane_tmp_keychain"
-    )
+    keychain_path = File.expand_path("~/Library/Keychains/fastlane_tmp_keychain-db")
+    Open3.popen3(
+      "security", "import", cert_p12_path,
+      "-P", cert_password,
+      "-A", "-t", "cert", "-f", "pkcs12",
+      "-k", keychain_path
+    ) do |_stdin, _stdout, stderr, wait_thr|
+      err = stderr.read
+      unless wait_thr.value.success?
+        UI.user_error!("Certificate import failed: #{err}")
+      end
+    end
+    sh("security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '' #{Shellwords.escape(keychain_path)}", log: false)
+    UI.success("Signing certificate imported successfully")
   end
 
   provisioning_profiles = Actions.lane_context[Fastlane::Actions::SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}


### PR DESCRIPTION
import_certificate also fails with MAC verification error because Fastlane concatenates the password into a shell string without escaping and omits the -f pkcs12 format flag.

Use Open3.popen3 with array args (no shell interpolation) and the exact security import flags from the working production workflow: -A -t cert -f pkcs12