### PR TITLE
fix(android): make notification tray Approve/Reject buttons functional

### DIFF
--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -20,22 +20,43 @@ const validateSessionWithRetry = (callback, retries = 3, interval = 1000) => {
   checkSession();
 };
 
-const sendUserAction = (appId, action) => {
+const sendUserAction = (userId, action, notificationId, deviceUUID) => {
   validateSessionWithRetry(() => {
     Meteor.call(
       "notifications.handleResponse",
-      appId,
+      userId,
       action,
+      notificationId,
+      deviceUUID,
       (error, result) => {
-        if (error) {
-          Session.set("notificationReceivedId", {
-            appId,
+        // Clear the in-flight flag so future notifications can open the modal
+        Session.set("actionPerformedFromTray", false);
+        // Clear any stale persisted notification so a later resume event
+        // doesn't reopen the modal for an already-handled notification.
+        try {
+          localStorage.removeItem("pendingNotification");
+        } catch {}
+
+        // Treat both transport errors and server-returned { success: false }
+        // as failures — otherwise the success modal lies when the server
+        // couldn't find/update the notification (e.g. expired or missing).
+        const failed = error || (result && result.success === false);
+
+        if (failed) {
+          const errorMsg = error
+            ? error.message || error.reason || String(error)
+            : result.message || "Unable to process action";
+          // Surface the error to the UI layer so it can fall back to the modal
+          Session.set("trayActionResult", {
+            notificationId,
+            action,
             status: "error",
-            error: error.message,
+            error: errorMsg,
           });
         } else {
-          Session.set("notificationReceivedId", {
-            appId,
+          Session.set("trayActionResult", {
+            notificationId,
+            action,
             status: action === "approve" ? "approved" : "rejected",
             timestamp: new Date().getTime(),
           });
@@ -97,19 +118,82 @@ const setupRegistrationHandler = (push) => {
   });
 };
 
+const handleActionFromTray = (push, action, data) => {
+  const additionalData = data.additionalData || {};
+  const userId = additionalData.userId;
+  const notificationId = additionalData.notificationId;
+
+  // Both fields are required for the server to identify the exact pending
+  // notification and verify the caller's ownership. If either is missing the
+  // payload is malformed — bail out so the existing modal flow can recover.
+  if (!userId || !notificationId) {
+    console.warn(
+      "Tray action received without userId/notificationId; skipping.",
+    );
+    return;
+  }
+
+  const deviceUUID = Session.get("capturedDeviceInfo")?.uuid || null;
+
+  Session.set("actionPerformedFromTray", true);
+
+  if (additionalData.coldstart) {
+    setTimeout(() => {
+      validateSessionWithRetry(() => {
+        sendUserAction(userId, action, notificationId, deviceUUID);
+      });
+    }, 2000);
+  } else {
+    sendUserAction(userId, action, notificationId, deviceUUID);
+  }
+
+  push.finish(
+    () => {},
+    () => {},
+    additionalData.notId,
+  );
+};
+
+const setupActionHandlers = (push) => {
+  push.on("approve", (data) => {
+    handleActionFromTray(push, "approve", data);
+  });
+
+  push.on("reject", (data) => {
+    handleActionFromTray(push, "reject", data);
+  });
+};
+
 const setupNotificationHandler = (push) => {
   push.on("notification", (notification) => {
     Meteor.startup(() => {
       const additionalData = notification.additionalData || {};
 
-      // Cold start handling
-      if (additionalData.coldstart) {
+      // Skip if action was already handled from the notification tray
+      if (Session.get("actionPerformedFromTray")) {
+        Session.set("actionPerformedFromTray", false);
+        return;
+      }
+
+      // Cold start handling — if the server attached an explicit action to the
+      // notification body (rare; main flow uses dedicated approve/reject
+      // events), forward it. Requires both userId and notificationId.
+      if (
+        additionalData.coldstart &&
+        additionalData.action &&
+        additionalData.userId &&
+        additionalData.notificationId
+      ) {
+        const deviceUUID = Session.get("capturedDeviceInfo")?.uuid || null;
         setTimeout(() => {
-          if (additionalData.action && additionalData.appId) {
-            validateSessionWithRetry(() => {
-              sendUserAction(additionalData.appId, additionalData.action);
-            });
-          }
+          validateSessionWithRetry(() => {
+            sendUserAction(
+              additionalData.userId,
+              additionalData.action,
+              additionalData.notificationId,
+              deviceUUID,
+            );
+          });
         }, 2000);
       }
 
@@ -146,6 +230,7 @@ export const initializePushNotifications = () => {
 
     // Register handlers
     setupRegistrationHandler(push);
+    setupActionHandlers(push);
     setupNotificationHandler(push);
     setupErrorHandler(push);
 

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -138,10 +138,11 @@ const handleActionFromTray = (push, action, data) => {
   Session.set("actionPerformedFromTray", true);
 
   if (additionalData.coldstart) {
+    // sendUserAction internally wraps the Meteor call in validateSessionWithRetry,
+    // so we only need a short delay to give the app a chance to boot. A second
+    // outer retry loop here would just multiply the wait time.
     setTimeout(() => {
-      validateSessionWithRetry(() => {
-        sendUserAction(userId, action, notificationId, deviceUUID);
-      });
+      sendUserAction(userId, action, notificationId, deviceUUID);
     }, 2000);
   } else {
     sendUserAction(userId, action, notificationId, deviceUUID);
@@ -169,9 +170,12 @@ const setupNotificationHandler = (push) => {
     Meteor.startup(() => {
       const additionalData = notification.additionalData || {};
 
-      // Skip if action was already handled from the notification tray
+      // Skip if action was already handled from the notification tray. Do NOT
+      // clear the flag here — the tray-action request may still be in flight,
+      // and clearing early can let the resume/tracker paths reopen the actions
+      // modal for the same notification. The sendUserAction callback clears
+      // the flag once the server call settles.
       if (Session.get("actionPerformedFromTray")) {
-        Session.set("actionPerformedFromTray", false);
         return;
       }
 

--- a/client/mobile/src/ui/Login.jsx
+++ b/client/mobile/src/ui/Login.jsx
@@ -154,6 +154,15 @@ export const LoginPage = ({ deviceDetails }) => {
               if (!result?._id)
                 throw new Error("Biometric authentication failed");
 
+              // Establish a real Meteor session so server methods see this.userId
+              if (result.token) {
+                await new Promise((res, rej) => {
+                  Meteor.loginWithToken(result.token, (err) =>
+                    err ? rej(err) : res(),
+                  );
+                });
+              }
+
               const isApproved = await checkRegistrationStatus(
                 result._id,
                 result.email,

--- a/client/mobile/src/ui/hooks/useNotificationHandler.js
+++ b/client/mobile/src/ui/hooks/useNotificationHandler.js
@@ -32,6 +32,11 @@ export const useNotificationHandler = (userId, username) => {
   // Background notification persistence
   useEffect(() => {
     const handleAppResume = () => {
+      // Skip modal restoration when an action is being processed from the
+      // notification tray — the action handler will resolve the notification
+      // server-side without any user interaction.
+      if (Session.get("actionPerformedFromTray")) return;
+
       const pendingNotification = localStorage.getItem("pendingNotification");
       if (pendingNotification) {
         const { appId, notificationId, createdAt } =
@@ -55,6 +60,10 @@ export const useNotificationHandler = (userId, username) => {
       const notificationData = Session.get("notificationReceivedId");
       if (!notificationData) return;
 
+      // Skip if an action is being processed from the notification tray.
+      // The tray handler will call notifications.handleResponse directly.
+      if (Session.get("actionPerformedFromTray")) return;
+
       // Handle cold start notification
       if (notificationData.coldstart) {
         localStorage.setItem(
@@ -73,6 +82,40 @@ export const useNotificationHandler = (userId, username) => {
       } catch {
         // Silently handled — reactive tracker will retry
       }
+    });
+
+    return () => tracker.stop();
+  }, [userId, getLatestPendingNotification]);
+
+  // React to tray-initiated actions: show the result modal on success or fall
+  // back to opening the actions modal on failure so the user can retry.
+  useEffect(() => {
+    if (!userId) return;
+
+    const tracker = Tracker.autorun(() => {
+      const result = Session.get("trayActionResult");
+      if (!result) return;
+
+      // Clear immediately so this only fires once
+      Session.set("trayActionResult", null);
+
+      if (result.status === "approved") {
+        setIsResultModalOpen(true);
+        setTimeout(() => setIsResultModalOpen(false), 3000);
+      } else if (result.status === "error") {
+        // Action failed silently — surface the modal so the user can retry
+        setActionError(
+          `Failed to ${result.action}: ${result.error || "Unknown error"}`,
+        );
+        getLatestPendingNotification().then((latestPending) => {
+          if (latestPending) {
+            setCurrentNotificationDetails(latestPending);
+            setNotificationIdForAction(latestPending.notificationId);
+            setIsActionsModalOpen(true);
+          }
+        });
+      }
+      // status === "rejected": no UI feedback needed, real-time subscription updates the list
     });
 
     return () => tracker.stop();

--- a/client/mobile/src/ui/hooks/useNotificationHandler.js
+++ b/client/mobile/src/ui/hooks/useNotificationHandler.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
@@ -13,6 +13,28 @@ export const useNotificationHandler = (userId, username) => {
     useState(null);
   const [isProcessingAction, setIsProcessingAction] = useState(false);
   const [actionError, setActionError] = useState(null);
+  const resultModalTimeoutRef = useRef(null);
+
+  const scheduleResultModalAutoClose = useCallback(() => {
+    if (resultModalTimeoutRef.current) {
+      clearTimeout(resultModalTimeoutRef.current);
+    }
+    resultModalTimeoutRef.current = setTimeout(() => {
+      setIsResultModalOpen(false);
+      resultModalTimeoutRef.current = null;
+    }, 3000);
+  }, []);
+
+  // Clear any pending auto-close timer on unmount to avoid setting state on
+  // an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (resultModalTimeoutRef.current) {
+        clearTimeout(resultModalTimeoutRef.current);
+        resultModalTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const getLatestPendingNotification = useCallback(async () => {
     if (!userId) return null;
@@ -101,7 +123,7 @@ export const useNotificationHandler = (userId, username) => {
 
       if (result.status === "approved") {
         setIsResultModalOpen(true);
-        setTimeout(() => setIsResultModalOpen(false), 3000);
+        scheduleResultModalAutoClose();
       } else if (result.status === "error") {
         // Action failed silently — surface the modal so the user can retry
         setActionError(
@@ -119,7 +141,7 @@ export const useNotificationHandler = (userId, username) => {
     });
 
     return () => tracker.stop();
-  }, [userId, getLatestPendingNotification]);
+  }, [userId, getLatestPendingNotification, scheduleResultModalAutoClose]);
 
   // Action handling with improved error states
   const sendUserAction = useCallback(
@@ -145,7 +167,7 @@ export const useNotificationHandler = (userId, username) => {
         setIsActionsModalOpen(false);
         if (action === "approve") {
           setIsResultModalOpen(true);
-          setTimeout(() => setIsResultModalOpen(false), 3000);
+          scheduleResultModalAutoClose();
         }
 
         // Subscription handles real-time updates automatically
@@ -155,7 +177,7 @@ export const useNotificationHandler = (userId, username) => {
         setIsProcessingAction(false);
       }
     },
-    [notificationIdForAction, username],
+    [notificationIdForAction, userId, scheduleResultModalAutoClose],
   );
 
   // Modal state cleanup
@@ -227,7 +249,13 @@ export const useNotificationHandler = (userId, username) => {
     actionError,
     handleApprove: () => sendUserAction("approve"),
     handleReject: () => sendUserAction("reject"),
-    handleCloseResultModal: () => setIsResultModalOpen(false),
+    handleCloseResultModal: () => {
+      if (resultModalTimeoutRef.current) {
+        clearTimeout(resultModalTimeoutRef.current);
+        resultModalTimeoutRef.current = null;
+      }
+      setIsResultModalOpen(false);
+    },
     handleCloseActionModal,
     openNotificationModal,
   };

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -218,8 +218,8 @@ export const sendDeviceApprovalNotification = async (userId, newDeviceUUID) => {
         title,
         body,
         actions: [
-          { id: "approve", title: "Approve" },
-          { id: "reject", title: "Reject" },
+          { callback: "approve", title: "Approve", foreground: true },
+          { callback: "reject", title: "Reject", foreground: true },
         ],
       }),
     });
@@ -278,8 +278,8 @@ export const sendSecondaryDeviceApprovalRequest = async (
         newDeviceUUID: newDevice.deviceUUID,
         userId: userId,
         actions: JSON.stringify([
-          { id: "approve", title: "Approve" },
-          { id: "reject", title: "Reject" },
+          { callback: "approve", title: "Approve", foreground: true },
+          { callback: "reject", title: "Reject", foreground: true },
         ]),
       },
     );

--- a/server/main.js
+++ b/server/main.js
@@ -695,6 +695,15 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
         clientId,
       });
 
+      // Without a notificationId the FCM tray-action buttons can never be
+      // correlated back to a pending record, so abort instead of sending a
+      // push the client can't act on.
+      if (!notificationId) {
+        throw new Error(
+          "Failed to create notification history record; aborting push.",
+        );
+      }
+
       // Prepare notification data
       const notificationData = {
         appId: primaryDevice.appId,
@@ -750,7 +759,25 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
         },
       );
 
-      await Promise.all(notificationPromises);
+      try {
+        await Promise.all(notificationPromises);
+      } catch (sendError) {
+        // Mark the pre-created history record as timed-out so it doesn't
+        // linger as a "pending" approval request the user can never resolve.
+        try {
+          await Meteor.callAsync(
+            "notificationHistory.updateStatus",
+            notificationId,
+            "timeout",
+          );
+        } catch (cleanupError) {
+          console.error(
+            "Failed to mark notification history as timeout after send error:",
+            cleanupError,
+          );
+        }
+        throw sendError;
+      }
 
       // Create a unique request ID for this notification
       const requestId = Random.id();

--- a/server/main.js
+++ b/server/main.js
@@ -685,9 +685,21 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
       const primaryDevice =
         approvedDevices.find((d) => d.isPrimary === true) || approvedDevices[0];
 
+      // Pre-create notification history so the notificationId can be embedded
+      // in the FCM data payload — required for tray-action handlers to reference
+      // the exact notification when calling notifications.handleResponse.
+      const notificationId = await saveUserNotificationHistory({
+        title,
+        body: messageBody,
+        userId: userDoc.userId,
+        clientId,
+      });
+
       // Prepare notification data
       const notificationData = {
         appId: primaryDevice.appId,
+        userId: userDoc.userId,
+        notificationId,
         messageFrom: "mie",
         notificationType: "approval",
         content_available: "1",
@@ -696,7 +708,13 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
         notId: "10",
         isDismissal: "false",
         isSync: "false",
-        actions: JSON.stringify(actions),
+        actions: JSON.stringify(
+          actions.map((a) => ({
+            callback: a.callback || a.id,
+            title: a.title,
+            foreground: a.foreground !== undefined ? a.foreground : true,
+          })),
+        ),
         click_action: "FLUTTER_NOTIFICATION_CLICK",
         sound: "default",
         platform: "both",
@@ -733,14 +751,6 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
       );
 
       await Promise.all(notificationPromises);
-
-      // Save notification history with clientId
-      await saveUserNotificationHistory({
-        title,
-        body: messageBody,
-        userId: userDoc.userId,
-        clientId,
-      });
 
       // Create a unique request ID for this notification
       const requestId = Random.id();
@@ -1321,9 +1331,18 @@ Meteor.methods({
     respondingDeviceUUID = null,
   ) {
     check(userId, String);
-    check(action, String);
+    check(action, Match.OneOf("approve", "reject"));
     check(notificationIdForAction, String);
     if (respondingDeviceUUID) check(respondingDeviceUUID, String);
+
+    // Require an authenticated Meteor session — anonymous callers must not be
+    // able to approve or reject another user's pending notifications.
+    if (!this.userId) {
+      throw new Meteor.Error(
+        "not-authenticated",
+        "You must be logged in to respond to notifications.",
+      );
+    }
 
     // Fetch user to get the username
     const user = await Meteor.users.findOneAsync(
@@ -1338,27 +1357,42 @@ Meteor.methods({
     const username = user.username;
     const resolvedUserId = user._id;
 
-    // Check if the responding device is approved
+    // Caller may only respond on behalf of themselves.
+    if (this.userId !== resolvedUserId) {
+      console.warn(
+        `User ${this.userId} attempted to respond to a notification belonging to ${resolvedUserId}. Blocking.`,
+      );
+      throw new Meteor.Error(
+        "not-authorized",
+        "You may only respond to your own notifications.",
+      );
+    }
+
+    // Check if the responding device is approved AND owned by the caller.
     if (respondingDeviceUUID) {
       const userDeviceDoc = await DeviceDetails.findOneAsync({
         userId: resolvedUserId,
       });
-      if (userDeviceDoc && userDeviceDoc.devices) {
-        const respondingDevice = userDeviceDoc.devices.find(
-          (d) => d.deviceUUID === respondingDeviceUUID,
+      const respondingDevice = userDeviceDoc?.devices?.find(
+        (d) => d.deviceUUID === respondingDeviceUUID,
+      );
+      if (!respondingDevice) {
+        console.warn(
+          `Device ${respondingDeviceUUID} is not registered to user ${username}. Blocking notification response.`,
         );
-        if (
-          respondingDevice &&
-          respondingDevice.deviceRegistrationStatus !== "approved"
-        ) {
-          console.warn(
-            `Device ${respondingDeviceUUID} for user ${username} is not approved (status: ${respondingDevice.deviceRegistrationStatus}). Blocking notification response.`,
-          );
-          throw new Meteor.Error(
-            "device-not-approved",
-            "Your device registration is still pending admin approval. You cannot respond to notifications until your device is approved.",
-          );
-        }
+        throw new Meteor.Error(
+          "device-not-owned",
+          "This device is not registered to your account.",
+        );
+      }
+      if (respondingDevice.deviceRegistrationStatus !== "approved") {
+        console.warn(
+          `Device ${respondingDeviceUUID} for user ${username} is not approved (status: ${respondingDevice.deviceRegistrationStatus}). Blocking notification response.`,
+        );
+        throw new Meteor.Error(
+          "device-not-approved",
+          "Your device registration is still pending admin approval. You cannot respond to notifications until your device is approved.",
+        );
       }
     }
 
@@ -1518,6 +1552,11 @@ Meteor.methods({
       );
     }
 
+    // Issue a Meteor login token so the client can call Meteor.loginWithToken
+    // and establish a real DDP session (this.userId on subsequent method calls).
+    const stampedToken = Accounts._generateStampedLoginToken();
+    await Accounts._insertLoginToken(user._id, stampedToken);
+
     // Return necessary user information for the session
     return {
       _id: user._id,
@@ -1525,6 +1564,8 @@ Meteor.methods({
       username: user.username,
       deviceLogId: device._id,
       appId: device.appId,
+      token: stampedToken.token,
+      tokenExpires: Accounts._tokenExpiration(stampedToken.when),
     };
   },
 
@@ -2026,7 +2067,13 @@ Meteor.methods({
 
       const notificationData = {
         appId: fcmTokens[0], // Use first token as appId
-        actions: JSON.stringify(actions),
+        actions: JSON.stringify(
+          actions.map((a) => ({
+            callback: a.callback || a.id,
+            title: a.title,
+            foreground: a.foreground !== undefined ? a.foreground : true,
+          })),
+        ),
         messageFrom: "mie",
         notificationType: "approval",
         content_available: "1",

--- a/tests/main.js
+++ b/tests/main.js
@@ -13,40 +13,52 @@ describe("meteor-app", function () {
 
     describe("Screen lock-based session management", function () {
       it("should store pause state in localStorage", function () {
-        const STORAGE_KEY = 'appWasPaused';
-        
-        localStorage.setItem(STORAGE_KEY, 'true');
+        const STORAGE_KEY = "appWasPaused";
+
+        localStorage.setItem(STORAGE_KEY, "true");
         const pauseState = localStorage.getItem(STORAGE_KEY);
-        
-        assert.strictEqual(pauseState, 'true', "Should store pause state correctly");
-        
+
+        assert.strictEqual(
+          pauseState,
+          "true",
+          "Should store pause state correctly",
+        );
+
         // Cleanup
         localStorage.removeItem(STORAGE_KEY);
       });
 
       it("should detect when app was paused", function () {
-        const STORAGE_KEY = 'appWasPaused';
-        
+        const STORAGE_KEY = "appWasPaused";
+
         // Simulate app pause
-        localStorage.setItem(STORAGE_KEY, 'true');
-        
+        localStorage.setItem(STORAGE_KEY, "true");
+
         // Check if app was paused
-        const wasPaused = localStorage.getItem(STORAGE_KEY) === 'true';
-        assert.strictEqual(wasPaused, true, "Should detect that app was paused");
-        
+        const wasPaused = localStorage.getItem(STORAGE_KEY) === "true";
+        assert.strictEqual(
+          wasPaused,
+          true,
+          "Should detect that app was paused",
+        );
+
         // Cleanup
         localStorage.removeItem(STORAGE_KEY);
       });
 
       it("should handle no pause state gracefully", function () {
-        const STORAGE_KEY = 'appWasPaused';
-        
+        const STORAGE_KEY = "appWasPaused";
+
         // Ensure no stored state
         localStorage.removeItem(STORAGE_KEY);
-        
+
         // Check pause state
         const wasPaused = localStorage.getItem(STORAGE_KEY);
-        assert.strictEqual(wasPaused, null, "Should return null when no pause state exists");
+        assert.strictEqual(
+          wasPaused,
+          null,
+          "Should return null when no pause state exists",
+        );
       });
     });
   }
@@ -70,47 +82,49 @@ describe("meteor-app", function () {
       it("should clean up users with expired approval tokens", async function () {
         // Create a test user
         const userId = await Accounts.createUser({
-          email: 'test@example.com',
-          username: 'testuser',
-          password: 'testpass',
+          email: "test@example.com",
+          username: "testuser",
+          password: "testpass",
           profile: {
-            firstName: 'Test',
-            lastName: 'User',
-            registrationStatus: 'pending'
-          }
+            firstName: "Test",
+            lastName: "User",
+            registrationStatus: "pending",
+          },
         });
 
         // Create device details for the user
         await DeviceDetails.insertAsync({
           userId: userId,
-          email: 'test@example.com',
-          username: 'testuser',
-          firstName: 'Test',
-          lastName: 'User',
-          devices: [{
-            deviceUUID: 'test-device-uuid',
-            appId: 'test-app-id',
-            biometricSecret: 'test-secret',
-            fcmToken: 'test-fcm-token',
-            isFirstDevice: true,
-            isPrimary: true,
-            isSecondaryDevice: false,
-            deviceRegistrationStatus: 'pending',
-            lastUpdated: new Date()
-          }],
+          email: "test@example.com",
+          username: "testuser",
+          firstName: "Test",
+          lastName: "User",
+          devices: [
+            {
+              deviceUUID: "test-device-uuid",
+              appId: "test-app-id",
+              biometricSecret: "test-secret",
+              fcmToken: "test-fcm-token",
+              isFirstDevice: true,
+              isPrimary: true,
+              isSecondaryDevice: false,
+              deviceRegistrationStatus: "pending",
+              lastUpdated: new Date(),
+            },
+          ],
           createdAt: new Date(),
-          lastUpdated: new Date()
+          lastUpdated: new Date(),
         });
 
         // Create an expired approval token
         const expiredDate = new Date(Date.now() - 60 * 1000); // 1 minute ago
         await ApprovalTokens.insertAsync({
           userId: userId,
-          token: 'expired-token',
+          token: "expired-token",
           createdAt: new Date(Date.now() - 5 * 60 * 1000), // 5 minutes ago
           expiresAt: expiredDate,
           used: false,
-          action: null
+          action: null,
         });
 
         // Verify test data exists
@@ -119,7 +133,7 @@ describe("meteor-app", function () {
         assert.strictEqual(await ApprovalTokens.find().countAsync(), 1);
 
         // Run cleanup
-        const result = await Meteor.callAsync('users.cleanupExpiredApprovals');
+        const result = await Meteor.callAsync("users.cleanupExpiredApprovals");
 
         // Verify cleanup results
         assert.strictEqual(result.success, true);
@@ -136,25 +150,25 @@ describe("meteor-app", function () {
       it("should not clean up users with valid (non-expired) tokens", async function () {
         // Create a test user
         const userId = await Accounts.createUser({
-          email: 'test@example.com',
-          username: 'testuser',
-          password: 'testpass',
+          email: "test@example.com",
+          username: "testuser",
+          password: "testpass",
           profile: {
-            firstName: 'Test',
-            lastName: 'User',
-            registrationStatus: 'pending'
-          }
+            firstName: "Test",
+            lastName: "User",
+            registrationStatus: "pending",
+          },
         });
 
         // Create a valid (non-expired) approval token
         const futureDate = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes from now
         await ApprovalTokens.insertAsync({
           userId: userId,
-          token: 'valid-token',
+          token: "valid-token",
           createdAt: new Date(),
           expiresAt: futureDate,
           used: false,
-          action: null
+          action: null,
         });
 
         // Verify test data exists
@@ -162,7 +176,7 @@ describe("meteor-app", function () {
         assert.strictEqual(await ApprovalTokens.find().countAsync(), 1);
 
         // Run cleanup
-        const result = await Meteor.callAsync('users.cleanupExpiredApprovals');
+        const result = await Meteor.callAsync("users.cleanupExpiredApprovals");
 
         // Verify no cleanup occurred for valid tokens
         assert.strictEqual(result.success, true);
@@ -177,29 +191,29 @@ describe("meteor-app", function () {
       it("should not clean up approved users even with expired tokens", async function () {
         // Create an approved test user
         const userId = await Accounts.createUser({
-          email: 'test@example.com',
-          username: 'testuser',
-          password: 'testpass',
+          email: "test@example.com",
+          username: "testuser",
+          password: "testpass",
           profile: {
-            firstName: 'Test',
-            lastName: 'User',
-            registrationStatus: 'approved' // Already approved
-          }
+            firstName: "Test",
+            lastName: "User",
+            registrationStatus: "approved", // Already approved
+          },
         });
 
         // Create an expired approval token
         const expiredDate = new Date(Date.now() - 60 * 1000); // 1 minute ago
         await ApprovalTokens.insertAsync({
           userId: userId,
-          token: 'expired-token',
+          token: "expired-token",
           createdAt: new Date(Date.now() - 5 * 60 * 1000),
           expiresAt: expiredDate,
           used: true, // Token was used for approval
-          action: 'approved'
+          action: "approved",
         });
 
         // Run cleanup
-        const result = await Meteor.callAsync('users.cleanupExpiredApprovals');
+        const result = await Meteor.callAsync("users.cleanupExpiredApprovals");
 
         // Verify approved user was not removed
         assert.strictEqual(result.cleanedUsers, 0);
@@ -213,46 +227,48 @@ describe("meteor-app", function () {
       it("should completely remove user when admin rejects", async function () {
         // Create a test user
         const userId = await Accounts.createUser({
-          email: 'test@example.com',
-          username: 'testuser',
-          password: 'testpass',
+          email: "test@example.com",
+          username: "testuser",
+          password: "testpass",
           profile: {
-            firstName: 'Test',
-            lastName: 'User',
-            registrationStatus: 'pending'
-          }
+            firstName: "Test",
+            lastName: "User",
+            registrationStatus: "pending",
+          },
         });
 
         // Create device details
         await DeviceDetails.insertAsync({
           userId: userId,
-          email: 'test@example.com',
-          username: 'testuser',
-          firstName: 'Test',
-          lastName: 'User',
-          devices: [{
-            deviceUUID: 'test-device-uuid',
-            appId: 'test-app-id',
-            biometricSecret: 'test-secret',
-            fcmToken: 'test-fcm-token',
-            isFirstDevice: true,
-            isPrimary: true,
-            isSecondaryDevice: false,
-            deviceRegistrationStatus: 'pending',
-            lastUpdated: new Date()
-          }],
+          email: "test@example.com",
+          username: "testuser",
+          firstName: "Test",
+          lastName: "User",
+          devices: [
+            {
+              deviceUUID: "test-device-uuid",
+              appId: "test-app-id",
+              biometricSecret: "test-secret",
+              fcmToken: "test-fcm-token",
+              isFirstDevice: true,
+              isPrimary: true,
+              isSecondaryDevice: false,
+              deviceRegistrationStatus: "pending",
+              lastUpdated: new Date(),
+            },
+          ],
           createdAt: new Date(),
-          lastUpdated: new Date()
+          lastUpdated: new Date(),
         });
 
         // Create approval token
         await ApprovalTokens.insertAsync({
           userId: userId,
-          token: 'test-token',
+          token: "test-token",
           createdAt: new Date(),
           expiresAt: new Date(Date.now() + 5 * 60 * 1000),
           used: false,
-          action: null
+          action: null,
         });
 
         // Verify test data exists
@@ -261,7 +277,7 @@ describe("meteor-app", function () {
         assert.strictEqual(await ApprovalTokens.find().countAsync(), 1);
 
         // Remove user completely
-        const result = await Meteor.callAsync('users.removeCompletely', userId);
+        const result = await Meteor.callAsync("users.removeCompletely", userId);
 
         // Verify removal was successful
         assert.strictEqual(result.success, true);
@@ -280,55 +296,105 @@ describe("meteor-app", function () {
       const { errorTemplate } = require("../server/templates/email");
 
       it("should render expired token error message", function () {
-        const html = errorTemplate('expired');
-        
-        assert.ok(html.includes('Token Expired'), "Should show 'Token Expired' title");
-        assert.ok(html.includes('The approval token has expired'), "Should show expired message");
-        assert.ok(html.includes('Please request a new approval link'), "Should show details");
+        const html = errorTemplate("expired");
+
+        assert.ok(
+          html.includes("Token Expired"),
+          "Should show 'Token Expired' title",
+        );
+        assert.ok(
+          html.includes("The approval token has expired"),
+          "Should show expired message",
+        );
+        assert.ok(
+          html.includes("Please request a new approval link"),
+          "Should show details",
+        );
       });
 
       it("should render user not found error message", function () {
-        const html = errorTemplate('user_not_found');
-        
-        assert.ok(html.includes('User Not Found'), "Should show 'User Not Found' title");
-        assert.ok(html.includes('The user associated with this approval token was not found'), "Should show user not found message");
-        assert.ok(html.includes('user registered a new account'), "Should explain the reason");
+        const html = errorTemplate("user_not_found");
+
+        assert.ok(
+          html.includes("User Not Found"),
+          "Should show 'User Not Found' title",
+        );
+        assert.ok(
+          html.includes(
+            "The user associated with this approval token was not found",
+          ),
+          "Should show user not found message",
+        );
+        assert.ok(
+          html.includes("user registered a new account"),
+          "Should explain the reason",
+        );
       });
 
       it("should render invalid token error message", function () {
-        const html = errorTemplate('invalid_token');
-        
-        assert.ok(html.includes('Invalid Token'), "Should show 'Invalid Token' title");
-        assert.ok(html.includes('The approval token is invalid or does not exist'), "Should show invalid token message");
+        const html = errorTemplate("invalid_token");
+
+        assert.ok(
+          html.includes("Invalid Token"),
+          "Should show 'Invalid Token' title",
+        );
+        assert.ok(
+          html.includes("The approval token is invalid or does not exist"),
+          "Should show invalid token message",
+        );
       });
 
       it("should render unknown error message for unrecognized reasons", function () {
-        const html = errorTemplate('some_unknown_reason');
-        
-        assert.ok(html.includes('Invalid Request'), "Should show default 'Invalid Request' title");
-        assert.ok(html.includes('This link is invalid or has expired'), "Should show default message");
+        const html = errorTemplate("some_unknown_reason");
+
+        assert.ok(
+          html.includes("Invalid Request"),
+          "Should show default 'Invalid Request' title",
+        );
+        assert.ok(
+          html.includes("This link is invalid or has expired"),
+          "Should show default message",
+        );
       });
 
       it("should render unknown error message when no reason is provided", function () {
         const html = errorTemplate();
-        
-        assert.ok(html.includes('Invalid Request'), "Should show default 'Invalid Request' title");
-        assert.ok(html.includes('This link is invalid or has expired'), "Should show default message");
+
+        assert.ok(
+          html.includes("Invalid Request"),
+          "Should show default 'Invalid Request' title",
+        );
+        assert.ok(
+          html.includes("This link is invalid or has expired"),
+          "Should show default message",
+        );
       });
 
       it("should always include error styling", function () {
-        const html = errorTemplate('expired');
-        
-        assert.ok(html.includes('error-message'), "Should include error-message class");
-        assert.ok(html.includes('background-color: #f44336'), "Should include error background color");
+        const html = errorTemplate("expired");
+
+        assert.ok(
+          html.includes("error-message"),
+          "Should include error-message class",
+        );
+        assert.ok(
+          html.includes("background-color: #f44336"),
+          "Should include error background color",
+        );
       });
 
       it("should render server error message", function () {
-        const html = errorTemplate('server_error');
-        
-        assert.ok(html.includes('Internal Server Error'), "Should show 'Internal Server Error' title");
-        assert.ok(html.includes('An internal server error occurred'), "Should show server error message");
-        assert.ok(html.includes('try again later'), "Should suggest retrying");
+        const html = errorTemplate("server_error");
+
+        assert.ok(
+          html.includes("Internal Server Error"),
+          "Should show 'Internal Server Error' title",
+        );
+        assert.ok(
+          html.includes("An internal server error occurred"),
+          "Should show server error message",
+        );
+        assert.ok(html.includes("try again later"), "Should suggest retrying");
       });
     });
 
@@ -336,8 +402,8 @@ describe("meteor-app", function () {
       const { ApprovalTokens } = require("../utils/api/approvalTokens");
       const { determineTokenErrorReason } = require("../utils/utils");
 
-      const testUserId = 'test-user-error-reason';
-      const testToken = 'test-token-error-reason';
+      const testUserId = "test-user-error-reason";
+      const testToken = "test-token-error-reason";
 
       afterEach(async function () {
         await ApprovalTokens.removeAsync({ userId: testUserId });
@@ -349,11 +415,11 @@ describe("meteor-app", function () {
           userId: testUserId,
           token: testToken,
           expiresAt: new Date(Date.now() - 1000), // expired 1 second ago
-          used: false
+          used: false,
         });
 
         const reason = await determineTokenErrorReason(testUserId, testToken);
-        assert.strictEqual(reason, 'expired');
+        assert.strictEqual(reason, "expired");
       });
 
       it("should return 'expired' when expiresAt equals current time (boundary)", async function () {
@@ -362,11 +428,11 @@ describe("meteor-app", function () {
           userId: testUserId,
           token: testToken,
           expiresAt: now,
-          used: false
+          used: false,
         });
 
         const reason = await determineTokenErrorReason(testUserId, testToken);
-        assert.strictEqual(reason, 'expired');
+        assert.strictEqual(reason, "expired");
       });
 
       it("should return 'user_not_found' when token exists, not expired, but user missing", async function () {
@@ -374,12 +440,12 @@ describe("meteor-app", function () {
           userId: testUserId,
           token: testToken,
           expiresAt: new Date(Date.now() + 60000), // expires in 1 minute
-          used: false
+          used: false,
         });
         // No user inserted
 
         const reason = await determineTokenErrorReason(testUserId, testToken);
-        assert.strictEqual(reason, 'user_not_found');
+        assert.strictEqual(reason, "user_not_found");
       });
 
       it("should return 'invalid_token' when token doesn't exist but user does", async function () {
@@ -387,19 +453,23 @@ describe("meteor-app", function () {
         // No token inserted
 
         const reason = await determineTokenErrorReason(testUserId, testToken);
-        assert.strictEqual(reason, 'invalid_token');
+        assert.strictEqual(reason, "invalid_token");
       });
 
       it("should return 'user_not_found' when neither token nor user exist", async function () {
         // No token or user inserted
         const reason = await determineTokenErrorReason(testUserId, testToken);
-        assert.strictEqual(reason, 'user_not_found');
+        assert.strictEqual(reason, "user_not_found");
       });
     });
 
     describe("API Key Authentication", function () {
-      const { ApiKeys, hashApiKey, verifyApiKey } = require("../utils/api/apiKeys");
-      const crypto = require('crypto');
+      const {
+        ApiKeys,
+        hashApiKey,
+        verifyApiKey,
+      } = require("../utils/api/apiKeys");
+      const crypto = require("crypto");
 
       beforeEach(async function () {
         // Clean up API keys before each test
@@ -414,42 +484,62 @@ describe("meteor-app", function () {
       describe("hashApiKey function", function () {
         it("should produce consistent hashes with the same salt", function () {
           const apiKey = "test-api-key-123";
-          const salt = crypto.randomBytes(32).toString('hex');
-          
+          const salt = crypto.randomBytes(32).toString("hex");
+
           const result1 = hashApiKey(apiKey, salt);
           const result2 = hashApiKey(apiKey, salt);
-          
-          assert.strictEqual(result1.hashedKey, result2.hashedKey, "Same key and salt should produce same hash");
-          assert.strictEqual(result1.salt, result2.salt, "Salt should be returned unchanged");
+
+          assert.strictEqual(
+            result1.hashedKey,
+            result2.hashedKey,
+            "Same key and salt should produce same hash",
+          );
+          assert.strictEqual(
+            result1.salt,
+            result2.salt,
+            "Salt should be returned unchanged",
+          );
         });
 
         it("should produce different hashes with different salts", function () {
           const apiKey = "test-api-key-123";
-          const salt1 = crypto.randomBytes(32).toString('hex');
-          const salt2 = crypto.randomBytes(32).toString('hex');
-          
+          const salt1 = crypto.randomBytes(32).toString("hex");
+          const salt2 = crypto.randomBytes(32).toString("hex");
+
           const result1 = hashApiKey(apiKey, salt1);
           const result2 = hashApiKey(apiKey, salt2);
-          
-          assert.notStrictEqual(result1.hashedKey, result2.hashedKey, "Different salts should produce different hashes");
+
+          assert.notStrictEqual(
+            result1.hashedKey,
+            result2.hashedKey,
+            "Different salts should produce different hashes",
+          );
         });
 
         it("should generate a salt if none provided", function () {
           const apiKey = "test-api-key-123";
-          
+
           const result = hashApiKey(apiKey);
-          
+
           assert.ok(result.salt, "Should generate a salt");
-          assert.strictEqual(result.salt.length, 64, "Salt should be 64 hex characters (32 bytes)");
+          assert.strictEqual(
+            result.salt.length,
+            64,
+            "Salt should be 64 hex characters (32 bytes)",
+          );
           assert.ok(result.hashedKey, "Should generate a hash");
         });
 
         it("should produce a 128-character hex hash (64 bytes)", function () {
           const apiKey = "test-api-key-123";
-          
+
           const result = hashApiKey(apiKey);
-          
-          assert.strictEqual(result.hashedKey.length, 128, "Hash should be 128 hex characters");
+
+          assert.strictEqual(
+            result.hashedKey.length,
+            128,
+            "Hash should be 128 hex characters",
+          );
         });
       });
 
@@ -457,9 +547,9 @@ describe("meteor-app", function () {
         it("should return true for valid key/hash pairs", function () {
           const apiKey = "test-api-key-for-verification";
           const result = hashApiKey(apiKey);
-          
+
           const isValid = verifyApiKey(apiKey, result.hashedKey, result.salt);
-          
+
           assert.strictEqual(isValid, true, "Should verify correct API key");
         });
 
@@ -467,32 +557,40 @@ describe("meteor-app", function () {
           const apiKey = "correct-api-key";
           const wrongKey = "wrong-api-key";
           const result = hashApiKey(apiKey);
-          
+
           const isValid = verifyApiKey(wrongKey, result.hashedKey, result.salt);
-          
+
           assert.strictEqual(isValid, false, "Should reject incorrect API key");
         });
 
         it("should return false for incorrect salt", function () {
           const apiKey = "test-api-key";
           const result = hashApiKey(apiKey);
-          const wrongSalt = crypto.randomBytes(32).toString('hex');
-          
+          const wrongSalt = crypto.randomBytes(32).toString("hex");
+
           const isValid = verifyApiKey(apiKey, result.hashedKey, wrongSalt);
-          
-          assert.strictEqual(isValid, false, "Should reject with incorrect salt");
+
+          assert.strictEqual(
+            isValid,
+            false,
+            "Should reject with incorrect salt",
+          );
         });
       });
 
       describe("apiKeys.create method", function () {
         it("should create a new API key and return it", async function () {
           const clientId = "test-client.example.com";
-          
-          const apiKey = await Meteor.callAsync('apiKeys.create', clientId);
-          
+
+          const apiKey = await Meteor.callAsync("apiKeys.create", clientId);
+
           assert.ok(apiKey, "Should return an API key");
-          assert.strictEqual(apiKey.length, 64, "API key should be 64 hex characters");
-          
+          assert.strictEqual(
+            apiKey.length,
+            64,
+            "API key should be 64 hex characters",
+          );
+
           // Verify it was stored
           const stored = await ApiKeys.findOneAsync({ clientId });
           assert.ok(stored, "Should store the key in database");
@@ -503,34 +601,46 @@ describe("meteor-app", function () {
 
         it("should reject duplicate client IDs", async function () {
           const clientId = "duplicate-client.example.com";
-          
+
           // Create first key
-          await Meteor.callAsync('apiKeys.create', clientId);
-          
+          await Meteor.callAsync("apiKeys.create", clientId);
+
           // Try to create duplicate
           try {
-            await Meteor.callAsync('apiKeys.create', clientId);
+            await Meteor.callAsync("apiKeys.create", clientId);
             assert.fail("Should have thrown an error");
           } catch (error) {
-            assert.strictEqual(error.error, 'client-exists', "Should throw client-exists error");
+            assert.strictEqual(
+              error.error,
+              "client-exists",
+              "Should throw client-exists error",
+            );
           }
         });
 
         it("should reject 'unspecified' as client ID", async function () {
           try {
-            await Meteor.callAsync('apiKeys.create', 'unspecified');
+            await Meteor.callAsync("apiKeys.create", "unspecified");
             assert.fail("Should have thrown an error");
           } catch (error) {
-            assert.strictEqual(error.error, 'invalid-client-id', "Should throw invalid-client-id error");
+            assert.strictEqual(
+              error.error,
+              "invalid-client-id",
+              "Should throw invalid-client-id error",
+            );
           }
         });
 
         it("should reject 'UNSPECIFIED' (case-insensitive) as client ID", async function () {
           try {
-            await Meteor.callAsync('apiKeys.create', 'UNSPECIFIED');
+            await Meteor.callAsync("apiKeys.create", "UNSPECIFIED");
             assert.fail("Should have thrown an error");
           } catch (error) {
-            assert.strictEqual(error.error, 'invalid-client-id', "Should throw invalid-client-id error");
+            assert.strictEqual(
+              error.error,
+              "invalid-client-id",
+              "Should throw invalid-client-id error",
+            );
           }
         });
       });
@@ -538,72 +648,127 @@ describe("meteor-app", function () {
       describe("apiKeys.verify method", function () {
         it("should validate correct API keys", async function () {
           const clientId = "verify-test.example.com";
-          const apiKey = await Meteor.callAsync('apiKeys.create', clientId);
-          
-          const result = await Meteor.callAsync('apiKeys.verify', apiKey, clientId);
-          
-          assert.strictEqual(result.isValid, true, "Should validate correct key");
-          assert.strictEqual(result.clientId, clientId, "Should return correct client ID");
+          const apiKey = await Meteor.callAsync("apiKeys.create", clientId);
+
+          const result = await Meteor.callAsync(
+            "apiKeys.verify",
+            apiKey,
+            clientId,
+          );
+
+          assert.strictEqual(
+            result.isValid,
+            true,
+            "Should validate correct key",
+          );
+          assert.strictEqual(
+            result.clientId,
+            clientId,
+            "Should return correct client ID",
+          );
         });
 
         it("should validate correct API keys without client ID hint", async function () {
           const clientId = "verify-no-hint.example.com";
-          const apiKey = await Meteor.callAsync('apiKeys.create', clientId);
-          
-          const result = await Meteor.callAsync('apiKeys.verify', apiKey);
-          
-          assert.strictEqual(result.isValid, true, "Should validate correct key");
-          assert.strictEqual(result.clientId, clientId, "Should return correct client ID");
+          const apiKey = await Meteor.callAsync("apiKeys.create", clientId);
+
+          const result = await Meteor.callAsync("apiKeys.verify", apiKey);
+
+          assert.strictEqual(
+            result.isValid,
+            true,
+            "Should validate correct key",
+          );
+          assert.strictEqual(
+            result.clientId,
+            clientId,
+            "Should return correct client ID",
+          );
         });
 
         it("should reject incorrect API keys", async function () {
           const clientId = "reject-test.example.com";
-          await Meteor.callAsync('apiKeys.create', clientId);
-          
-          const result = await Meteor.callAsync('apiKeys.verify', 'wrong-api-key', clientId);
-          
-          assert.strictEqual(result.isValid, false, "Should reject incorrect key");
-          assert.strictEqual(result.clientId, null, "Should return null client ID");
+          await Meteor.callAsync("apiKeys.create", clientId);
+
+          const result = await Meteor.callAsync(
+            "apiKeys.verify",
+            "wrong-api-key",
+            clientId,
+          );
+
+          assert.strictEqual(
+            result.isValid,
+            false,
+            "Should reject incorrect key",
+          );
+          assert.strictEqual(
+            result.clientId,
+            null,
+            "Should return null client ID",
+          );
         });
 
         it("should reject API keys for non-existent clients", async function () {
-          const result = await Meteor.callAsync('apiKeys.verify', 'any-key', 'non-existent-client');
-          
-          assert.strictEqual(result.isValid, false, "Should reject key for non-existent client");
+          const result = await Meteor.callAsync(
+            "apiKeys.verify",
+            "any-key",
+            "non-existent-client",
+          );
+
+          assert.strictEqual(
+            result.isValid,
+            false,
+            "Should reject key for non-existent client",
+          );
         });
 
         it("should update lastUsed timestamp on successful verification", async function () {
           const clientId = "timestamp-test.example.com";
-          const apiKey = await Meteor.callAsync('apiKeys.create', clientId);
-          
+          const apiKey = await Meteor.callAsync("apiKeys.create", clientId);
+
           // Initially lastUsed should be null
           let stored = await ApiKeys.findOneAsync({ clientId });
-          assert.strictEqual(stored.lastUsed, null, "lastUsed should be null initially");
-          
+          assert.strictEqual(
+            stored.lastUsed,
+            null,
+            "lastUsed should be null initially",
+          );
+
           // Verify the key
-          await Meteor.callAsync('apiKeys.verify', apiKey, clientId);
-          
+          await Meteor.callAsync("apiKeys.verify", apiKey, clientId);
+
           // Check lastUsed was updated
           stored = await ApiKeys.findOneAsync({ clientId });
           assert.ok(stored.lastUsed, "lastUsed should be updated");
-          assert.ok(stored.lastUsed instanceof Date, "lastUsed should be a Date");
+          assert.ok(
+            stored.lastUsed instanceof Date,
+            "lastUsed should be a Date",
+          );
         });
 
         it("should reject 'unspecified' as client ID", async function () {
-          const result = await Meteor.callAsync('apiKeys.verify', 'any-key', 'unspecified');
-          
-          assert.strictEqual(result.isValid, false, "Should reject unspecified client ID");
+          const result = await Meteor.callAsync(
+            "apiKeys.verify",
+            "any-key",
+            "unspecified",
+          );
+
+          assert.strictEqual(
+            result.isValid,
+            false,
+            "Should reject unspecified client ID",
+          );
         });
       });
 
       describe("apiKeys.list method", function () {
         it("should return all keys with metadata", async function () {
           // Create some keys
-          await Meteor.callAsync('apiKeys.create', 'list-test-1.example.com');
-          await Meteor.callAsync('apiKeys.create', 'list-test-2.example.com');
-          
-          const keys = await Meteor.callAsync('apiKeys.list');
-          
+          await Meteor.callAsync("apiKeys.create", "list-test-1.example.com");
+          await Meteor.callAsync("apiKeys.create", "list-test-2.example.com");
+
+          const keys = await Meteor.callAsync("apiKeys.list");
+
           assert.strictEqual(keys.length, 2, "Should return 2 keys");
           assert.ok(keys[0].clientId, "Should include clientId");
           assert.ok(keys[0].createdAt, "Should include createdAt");
@@ -612,8 +777,8 @@ describe("meteor-app", function () {
         });
 
         it("should return empty array when no keys exist", async function () {
-          const keys = await Meteor.callAsync('apiKeys.list');
-          
+          const keys = await Meteor.callAsync("apiKeys.list");
+
           assert.strictEqual(keys.length, 0, "Should return empty array");
         });
       });
@@ -621,65 +786,102 @@ describe("meteor-app", function () {
       describe("apiKeys.delete method", function () {
         it("should delete an existing key", async function () {
           const clientId = "delete-test.example.com";
-          await Meteor.callAsync('apiKeys.create', clientId);
-          
-          const result = await Meteor.callAsync('apiKeys.delete', clientId);
-          
-          assert.strictEqual(result, true, "Should return true on successful delete");
-          
+          await Meteor.callAsync("apiKeys.create", clientId);
+
+          const result = await Meteor.callAsync("apiKeys.delete", clientId);
+
+          assert.strictEqual(
+            result,
+            true,
+            "Should return true on successful delete",
+          );
+
           // Verify it was deleted
           const stored = await ApiKeys.findOneAsync({ clientId });
           assert.strictEqual(stored, undefined, "Key should be deleted");
         });
 
         it("should return false for non-existent keys", async function () {
-          const result = await Meteor.callAsync('apiKeys.delete', 'non-existent-client');
-          
-          assert.strictEqual(result, false, "Should return false for non-existent key");
+          const result = await Meteor.callAsync(
+            "apiKeys.delete",
+            "non-existent-client",
+          );
+
+          assert.strictEqual(
+            result,
+            false,
+            "Should return false for non-existent key",
+          );
         });
       });
 
       describe("apiKeys.regenerate method", function () {
         it("should generate a new key and invalidate the old one", async function () {
           const clientId = "regenerate-test.example.com";
-          const oldKey = await Meteor.callAsync('apiKeys.create', clientId);
-          
-          const newKey = await Meteor.callAsync('apiKeys.regenerate', clientId);
-          
+          const oldKey = await Meteor.callAsync("apiKeys.create", clientId);
+
+          const newKey = await Meteor.callAsync("apiKeys.regenerate", clientId);
+
           assert.ok(newKey, "Should return new key");
           assert.notStrictEqual(newKey, oldKey, "New key should be different");
-          
+
           // Old key should no longer work
-          const oldResult = await Meteor.callAsync('apiKeys.verify', oldKey, clientId);
-          assert.strictEqual(oldResult.isValid, false, "Old key should be invalid");
-          
+          const oldResult = await Meteor.callAsync(
+            "apiKeys.verify",
+            oldKey,
+            clientId,
+          );
+          assert.strictEqual(
+            oldResult.isValid,
+            false,
+            "Old key should be invalid",
+          );
+
           // New key should work
-          const newResult = await Meteor.callAsync('apiKeys.verify', newKey, clientId);
-          assert.strictEqual(newResult.isValid, true, "New key should be valid");
+          const newResult = await Meteor.callAsync(
+            "apiKeys.verify",
+            newKey,
+            clientId,
+          );
+          assert.strictEqual(
+            newResult.isValid,
+            true,
+            "New key should be valid",
+          );
         });
 
         it("should reject regeneration for non-existent clients", async function () {
           try {
-            await Meteor.callAsync('apiKeys.regenerate', 'non-existent-client');
+            await Meteor.callAsync("apiKeys.regenerate", "non-existent-client");
             assert.fail("Should have thrown an error");
           } catch (error) {
-            assert.strictEqual(error.error, 'client-not-found', "Should throw client-not-found error");
+            assert.strictEqual(
+              error.error,
+              "client-not-found",
+              "Should throw client-not-found error",
+            );
           }
         });
 
         it("should reject 'unspecified' as client ID", async function () {
           try {
-            await Meteor.callAsync('apiKeys.regenerate', 'unspecified');
+            await Meteor.callAsync("apiKeys.regenerate", "unspecified");
             assert.fail("Should have thrown an error");
           } catch (error) {
-            assert.strictEqual(error.error, 'invalid-client-id', "Should throw invalid-client-id error");
+            assert.strictEqual(
+              error.error,
+              "invalid-client-id",
+              "Should throw invalid-client-id error",
+            );
           }
         });
       });
     });
 
     describe("Notification History clientId tracking", function () {
-      const { NotificationHistory } = require("../utils/api/notificationHistory");
+      const {
+        NotificationHistory,
+      } = require("../utils/api/notificationHistory");
 
       beforeEach(async function () {
         await NotificationHistory.removeAsync({});
@@ -690,37 +892,57 @@ describe("meteor-app", function () {
       });
 
       it("should default clientId to 'unspecified' when not provided", async function () {
-        const notificationId = await Meteor.callAsync('notificationHistory.insert', {
-          userId: 'test-user-id',
-          title: 'Test Notification',
-          body: 'Test body'
+        const notificationId = await Meteor.callAsync(
+          "notificationHistory.insert",
+          {
+            userId: "test-user-id",
+            title: "Test Notification",
+            body: "Test body",
+          },
+        );
+
+        const notification = await NotificationHistory.findOneAsync({
+          notificationId,
         });
-        
-        const notification = await NotificationHistory.findOneAsync({ _id: notificationId });
-        
-        assert.strictEqual(notification.clientId, 'unspecified', "Should default to 'unspecified'");
+
+        assert.strictEqual(
+          notification.clientId,
+          "unspecified",
+          "Should default to 'unspecified'",
+        );
       });
 
       it("should store provided clientId", async function () {
-        const clientId = 'ldap.example.com';
-        const notificationId = await Meteor.callAsync('notificationHistory.insert', {
-          userId: 'test-user-id',
-          title: 'Test Notification',
-          body: 'Test body',
-          clientId: clientId
+        const clientId = "ldap.example.com";
+        const notificationId = await Meteor.callAsync(
+          "notificationHistory.insert",
+          {
+            userId: "test-user-id",
+            title: "Test Notification",
+            body: "Test body",
+            clientId: clientId,
+          },
+        );
+
+        const notification = await NotificationHistory.findOneAsync({
+          notificationId,
         });
-        
-        const notification = await NotificationHistory.findOneAsync({ _id: notificationId });
-        
-        assert.strictEqual(notification.clientId, clientId, "Should store provided clientId");
+
+        assert.strictEqual(
+          notification.clientId,
+          clientId,
+          "Should store provided clientId",
+        );
       });
     });
 
     describe("Notification expiry checks", function () {
-      const { NotificationHistory } = require("../utils/api/notificationHistory");
+      const {
+        NotificationHistory,
+      } = require("../utils/api/notificationHistory");
       const { isNotificationExpired } = require("../utils/utils");
       const { TIMEOUT_DURATION_MS } = require("../utils/constants");
-      
+
       let testUserIds = [];
 
       beforeEach(async function () {
@@ -740,101 +962,157 @@ describe("meteor-app", function () {
       it("should identify expired notification", function () {
         const oldDate = new Date(Date.now() - TIMEOUT_DURATION_MS - 1000); // 1 second past expiry
         const isExpired = isNotificationExpired(oldDate);
-        assert.strictEqual(isExpired, true, "Should identify expired notification");
+        assert.strictEqual(
+          isExpired,
+          true,
+          "Should identify expired notification",
+        );
       });
 
       it("should identify non-expired notification", function () {
         const recentDate = new Date(Date.now() - 1000); // 1 second ago
         const isExpired = isNotificationExpired(recentDate);
-        assert.strictEqual(isExpired, false, "Should identify non-expired notification");
+        assert.strictEqual(
+          isExpired,
+          false,
+          "Should identify non-expired notification",
+        );
       });
 
       it("should handle string timestamp", function () {
-        const oldDateString = new Date(Date.now() - TIMEOUT_DURATION_MS - 1000).toISOString();
+        const oldDateString = new Date(
+          Date.now() - TIMEOUT_DURATION_MS - 1000,
+        ).toISOString();
         const isExpired = isNotificationExpired(oldDateString);
         assert.strictEqual(isExpired, true, "Should handle string timestamp");
       });
 
       it("should return true for null/undefined createdAt", function () {
-        assert.strictEqual(isNotificationExpired(null), true, "Should return true for null");
-        assert.strictEqual(isNotificationExpired(undefined), true, "Should return true for undefined");
+        assert.strictEqual(
+          isNotificationExpired(null),
+          true,
+          "Should return true for null",
+        );
+        assert.strictEqual(
+          isNotificationExpired(undefined),
+          true,
+          "Should return true for undefined",
+        );
       });
 
       it("should reject action on expired notification", async function () {
-        const userId = 'test-user-' + Random.id();
+        const userId = "test-user-" + Random.id();
         testUserIds.push(userId); // Track for cleanup
-        
+
         // Create a user
-        await Accounts.createUserAsync({
+        const createdUser = await Accounts.createUserAsync({
           username: userId,
           email: `${userId}@example.com`,
-          password: 'testpass'
+          password: "testpass",
         });
 
         // Insert an expired notification
-        const notificationId = await Meteor.callAsync('notificationHistory.insert', {
-          userId: userId,
-          title: 'Test Expired Notification',
-          body: 'This notification is expired'
-        });
+        const notificationId = await Meteor.callAsync(
+          "notificationHistory.insert",
+          {
+            userId: userId,
+            title: "Test Expired Notification",
+            body: "This notification is expired",
+          },
+        );
 
         // Get the notification and manually set an old createdAt
-        const notification = await NotificationHistory.findOneAsync({ _id: notificationId });
+        const notification = await NotificationHistory.findOneAsync({
+          notificationId,
+        });
         const expiredDate = new Date(Date.now() - TIMEOUT_DURATION_MS - 1000);
         await NotificationHistory.updateAsync(
           { _id: notification._id },
-          { $set: { createdAt: expiredDate } }
+          { $set: { createdAt: expiredDate } },
         );
 
-        // Try to handle response for expired notification
-        const result = await Meteor.callAsync(
-          'notifications.handleResponse',
-          userId,
-          'approve',
-          notification.notificationId
+        // Try to handle response for expired notification.
+        // The method now requires this.userId, so invoke the handler directly
+        // with a simulated authenticated context.
+        const handler =
+          Meteor.server.method_handlers["notifications.handleResponse"];
+        const result = await handler.apply(
+          { userId: createdUser, connection: null },
+          [userId, "approve", notification.notificationId],
         );
 
-        assert.strictEqual(result.success, false, "Should reject action on expired notification");
-        assert.strictEqual(result.message, "Notification has expired", "Should return correct error message");
+        assert.strictEqual(
+          result.success,
+          false,
+          "Should reject action on expired notification",
+        );
+        assert.strictEqual(
+          result.message,
+          "Notification has expired",
+          "Should return correct error message",
+        );
 
         // Verify notification was marked as timeout
-        const updatedNotification = await NotificationHistory.findOneAsync({ _id: notification._id });
-        assert.strictEqual(updatedNotification.status, 'timeout', "Should mark notification as timeout");
+        const updatedNotification = await NotificationHistory.findOneAsync({
+          _id: notification._id,
+        });
+        assert.strictEqual(
+          updatedNotification.status,
+          "timeout",
+          "Should mark notification as timeout",
+        );
       });
 
       it("should allow action on non-expired notification", async function () {
-        const userId = 'test-user-' + Random.id();
+        const userId = "test-user-" + Random.id();
         testUserIds.push(userId); // Track for cleanup
-        
+
         // Create a user
-        await Accounts.createUserAsync({
+        const createdUser = await Accounts.createUserAsync({
           username: userId,
           email: `${userId}@example.com`,
-          password: 'testpass'
+          password: "testpass",
         });
 
         // Insert a recent notification
-        const notificationId = await Meteor.callAsync('notificationHistory.insert', {
-          userId: userId,
-          title: 'Test Recent Notification',
-          body: 'This notification is recent'
-        });
-
-        const notification = await NotificationHistory.findOneAsync({ _id: notificationId });
-
-        // Try to handle response for non-expired notification
-        const result = await Meteor.callAsync(
-          'notifications.handleResponse',
-          userId,
-          'approve',
-          notification.notificationId
+        const notificationId = await Meteor.callAsync(
+          "notificationHistory.insert",
+          {
+            userId: userId,
+            title: "Test Recent Notification",
+            body: "This notification is recent",
+          },
         );
 
-        assert.strictEqual(result.success, true, "Should allow action on non-expired notification");
+        const notification = await NotificationHistory.findOneAsync({
+          notificationId,
+        });
+
+        // Try to handle response for non-expired notification.
+        // The method now requires this.userId, so invoke the handler directly
+        // with a simulated authenticated context.
+        const handler =
+          Meteor.server.method_handlers["notifications.handleResponse"];
+        const result = await handler.apply(
+          { userId: createdUser, connection: null },
+          [userId, "approve", notification.notificationId],
+        );
+
+        assert.strictEqual(
+          result.success,
+          true,
+          "Should allow action on non-expired notification",
+        );
 
         // Verify notification was updated with action
-        const updatedNotification = await NotificationHistory.findOneAsync({ _id: notification._id });
-        assert.strictEqual(updatedNotification.status, 'approve', "Should update notification with approve status");
+        const updatedNotification = await NotificationHistory.findOneAsync({
+          _id: notification._id,
+        });
+        assert.strictEqual(
+          updatedNotification.status,
+          "approve",
+          "Should update notification with approve status",
+        );
       });
     });
   }

--- a/tests/main.js
+++ b/tests/main.js
@@ -1002,7 +1002,6 @@ describe("meteor-app", function () {
 
       it("should reject action on expired notification", async function () {
         const userId = "test-user-" + Random.id();
-        testUserIds.push(userId); // Track for cleanup
 
         // Create a user
         const createdUser = await Accounts.createUserAsync({
@@ -1010,6 +1009,7 @@ describe("meteor-app", function () {
           email: `${userId}@example.com`,
           password: "testpass",
         });
+        testUserIds.push(createdUser); // Track _id for cleanup
 
         // Insert an expired notification
         const notificationId = await Meteor.callAsync(
@@ -1065,7 +1065,6 @@ describe("meteor-app", function () {
 
       it("should allow action on non-expired notification", async function () {
         const userId = "test-user-" + Random.id();
-        testUserIds.push(userId); // Track for cleanup
 
         // Create a user
         const createdUser = await Accounts.createUserAsync({
@@ -1073,6 +1072,7 @@ describe("meteor-app", function () {
           email: `${userId}@example.com`,
           password: "testpass",
         });
+        testUserIds.push(createdUser); // Track _id for cleanup
 
         // Insert a recent notification
         const notificationId = await Meteor.callAsync(

--- a/utils/api/notificationHistory.js
+++ b/utils/api/notificationHistory.js
@@ -17,7 +17,7 @@ if (Meteor.isServer) {
 
 Meteor.methods({
   // Insert a new notification into the history
-  "notificationHistory.insert": function (data) {
+  "notificationHistory.insert": async function (data) {
     check(
       data,
       Match.ObjectIncluding({
@@ -54,7 +54,12 @@ Meteor.methods({
     // Include clientId (defaults to 'unspecified' if not provided)
     insertData.clientId = data.clientId || "unspecified";
 
-    return NotificationHistory.insertAsync(insertData);
+    // Insert the document, then return the generated notificationId (NOT the
+    // mongo _id). The notificationId is the field the rest of the system
+    // queries against — returning _id here would silently break tray-action
+    // handling because notifications.handleResponse looks up by notificationId.
+    await NotificationHistory.insertAsync(insertData);
+    return notificationId;
   },
 
   // Update the status of a notification


### PR DESCRIPTION
Closes #366

## Problem

The Approve/Reject action buttons rendered on Android push notifications did nothing when tapped. The user-facing behavior was: tap Approve in the tray → app opens → biometric → in-app modal still shows up requiring another tap. The buttons saved zero clicks.

## Root causes

| # | Cause |
|---|---|
| 1 | FCM action payload used \`{ id }\` but \`@havesource/cordova-plugin-push@7\` requires \`{ callback }\`, and the named events (\`push.on('approve'/'reject')\`) were never registered. |
| 2 | \`saveUserNotificationHistory\` returned the mongo \`_id\` from \`insertAsync\` instead of the generated \`notificationId\` field, so the value embedded in the FCM payload could not be looked up by \`notifications.handleResponse\` (returned \`{success:false}\` silently). |
| 3 | Biometric login only set a Session var without calling \`Meteor.loginWithToken\`, so \`this.userId\` was null on subsequent method calls. |
| 4 | The in-app modal opened from multiple paths (\`Tracker.autorun\`, \`resume\` handler) that didn't know an action was already in flight from the tray. |
| 5 | \`notifications.handleResponse\` accepted any action string and had no authentication or ownership check. |

## Changes

- **server/main.js** – pre-create \`NotificationHistory\` and embed \`userId\` + \`notificationId\` in the FCM data payload; require \`this.userId\`, verify ownership, validate action with \`Match.OneOf\`, enforce device ownership; issue a stamped login token from \`users.loginWithBiometric\`.
- **server/firebase.js** – switch action format to \`{ callback, foreground }\` for cordova-plugin-push v7 compatibility.
- **client/mobile/push-notifications.js** – register \`push.on('approve'/'reject')\` handlers; pass userId/notificationId/deviceUUID; treat \`result.success === false\` as failure; clear in-flight flag and stale \`pendingNotification\` after the call settles.
- **client/mobile/src/ui/hooks/useNotificationHandler.js** – gate modal-opening paths on \`actionPerformedFromTray\` flag; new tracker on \`trayActionResult\` to flash the success modal or fall back to the actions modal on error.
- **client/mobile/src/ui/Login.jsx** – call \`Meteor.loginWithToken\` after biometric so the DDP session has a real userId.
- **utils/api/notificationHistory.js** – return the generated \`notificationId\` (not mongo \`_id\`) from \`notificationHistory.insert\`.
- **tests/main.js** – update tests for the new return value and invoke \`notifications.handleResponse\` with a simulated authenticated context.

## Security hardening (in scope, related to fix)

- Added authentication + ownership + device-ownership checks to \`notifications.handleResponse\` (previously any caller could approve/reject any user's notifications).
- Restricted \`action\` to \`Match.OneOf(\"approve\", \"reject\")\`.

## New UX

| Path | Before | After |
|---|---|---|
| Tap **Approve** in tray | tap action + biometric + tap Approve in modal = 3 interactions | tap action + biometric + brief success flash = **2 interactions** |
| Tap **Reject** in tray | same modal redundancy | tap action + biometric, silent dismiss = **2 interactions** |
| Tap notification body | unchanged | unchanged |
| Tray action **fails** (expired, etc.) | misleading success | modal opens with real error so user can retry |

## Scope

- **Android only** per request. iOS still requires pre-registered notification categories — left for a follow-up.

## Testing

- Manually verified end-to-end on Android: Approve from tray → biometric → green checkmark, notification disappears from Pending tab.
- Updated 4 existing tests in tests/main.js.