### PR TITLE
fix(css): prevent sticky header from being overlapped by welcome banner

### DIFF
--- a/client/mobile/src/ui/components/DashboardHeader.jsx
+++ b/client/mobile/src/ui/components/DashboardHeader.jsx
@@ -27,7 +27,7 @@ export const DashboardHeader = ({
   const iconLabel = "text-[9px] font-medium mt-0.5 leading-tight";
 
   return (
-    <header className="sticky top-0 z-10 bg-card shadow-sm">
+    <header className="sticky top-0 z-50 bg-card shadow-sm isolate">
       <div className="px-4 py-2.5">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">


### PR DESCRIPTION
Closes #365

## Problem

On both Android and iOS, the sticky `MIE Auth` header (with Refresh / Dark / Help / Logout buttons) was being overlapped by the welcome banner's avatar and gradient when the user scrolled. The avatar painted on top of the header bar.

## Root cause

The `DashboardHeader` used `z-10` for its sticky positioning, but the welcome banner's inner content also used `relative z-10`. With equal z-indices, DOM order wins — the banner appears later in the tree and painted over the header.

## Fix

- Bumped the header's z-index from `z-10` to `z-50`
- Added `isolate` to create its own stacking context, preventing any child of the banner from escaping into the header's layer

## Changed file

- **client/mobile/src/ui/components/DashboardHeader.jsx** — `sticky top-0 z-10 bg-card shadow-sm` → `sticky top-0 z-50 bg-card shadow-sm isolate`

## Testing

Verified on both Android and iOS that the header stays above the welcome banner on scroll.