### PR TITLE
fix: set CFBundleVersion separately instead of modifying marketing ve…

### DIFF
--- a/.github/workflows/test-ios-fastlane.yml
+++ b/.github/workflows/test-ios-fastlane.yml
@@ -25,8 +25,7 @@ jobs:
         run: |
           sed -i '' "s/id: ['\"]org.mieweb.opensource['\"]/id: 'org.mieweb.os.dev'/" mobile-config.js
           sed -i '' "s/name: ['\"]MIEAuth['\"]/name: 'MIEAuth Opensource Beta'/" mobile-config.js
-          BASE_VERSION=$(grep -oE "version: ['\"][0-9.]+['\"]" mobile-config.js | head -1 | grep -oE "[0-9.]+")
-          sed -i '' "s/version: ['\"][0-9.]*['\"]/version: '${BASE_VERSION}.${{ github.run_number }}'/" mobile-config.js
+          echo "App.setPreference('ios-CFBundleVersion', '${{ github.run_number }}');" >> mobile-config.js
 
       - uses: mieweb/actions/meteor-build@v1
         with:


### PR DESCRIPTION
…rsion

Apple requires CFBundleShortVersionString to be max 3 segments (X.Y.Z). Use ios-CFBundleVersion preference to set the build number independently using the GitHub run number for uniqueness.