### PR TITLE
fix(admin): pin Babel & React CDN versions to fix /admin crash in prod

### DIFF
--- a/server/templates/admin.js
+++ b/server/templates/admin.js
@@ -9,9 +9,12 @@ export const adminPageTemplate = () => `<!DOCTYPE html>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin Dashboard - MIEWeb Auth</title>
-  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
+  <!-- Pin Babel to v7: v8 (unpkg "latest") defaults JSX to the automatic runtime,
+       emitting \`import { jsx } from "react/jsx-runtime"\` which breaks this classic
+       (non-module) UMD setup with "Cannot use import statement outside a module". -->
+  <script src="https://unpkg.com/@babel/standalone@7.26.4/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }


### PR DESCRIPTION
## Problem
The `/admin` page crashes in production with:
```
Uncaught SyntaxError: Failed to execute 'appendChild' on 'Node': Cannot use import statement outside a module
```

## Root cause
[server/templates/admin.js](server/templates/admin.js) loads an **unpinned** `@babel/standalone` from unpkg and transforms an inline `<script type="text/babel">` at runtime. unpkg's `latest` now resolves to **Babel 8**, which changed the default JSX runtime from `classic` to `automatic`. The JSX is compiled to `import { jsx } from \"react/jsx-runtime\"`, which Babel then injects as a classic (non-module) script — causing the crash.

It didn't reproduce locally because browsers had an older Babel 7 cached; fresh prod clients pulled Babel 8.

## Fix
- Pin `@babel/standalone@7.26.4` (classic JSX runtime → `React.createElement`, no ESM import).
- Pin `react@18.3.1` / `react-dom@18.3.1` UMD globals for deterministic output.

No functional changes to the admin UI.