### PR TITLE
fix(admin-auth): match all LDAP group membership schemes

### DIFF
--- a/docs/ADMIN_DASHBOARD.md
+++ b/docs/ADMIN_DASHBOARD.md
@@ -10,21 +10,21 @@ Set the following LDAP env vars before starting the server:
 # Comma-separated for failover (tries ldap1 first, falls back to ldap2)
 export LDAP_URL="ldaps://ldap1.cluster.mieweb.org:636,ldaps://ldap2.cluster.mieweb.org:636"
 export LDAP_BASE_DN="dc=cluster,dc=mieweb,dc=org"
-export LDAP_USER_BASE_DN="ou=people,dc=cluster,dc=mieweb,dc=org"
-export LDAP_ADMIN_GROUP_DN="cn=tfa-admins,dc=cluster,dc=mieweb,dc=org"
+export LDAP_USER_BASE_DN="ou=users,dc=cluster,dc=mieweb,dc=org"
+export LDAP_ADMIN_GROUP_DN="cn=tfa-admins,ou=groups,dc=cluster,dc=mieweb,dc=org"
 # optional – defaults to "memberUid"
 # export LDAP_GROUP_MEMBER_ATTR="memberUid"
 export LDAP_REJECT_UNAUTHORIZED="false"
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `LDAP_URL` | Yes | LDAP server URL(s). Comma-separated for failover (e.g. `ldaps://ldap1:636,ldaps://ldap2:636`) |
-| `LDAP_BASE_DN` | Yes | Base DN for the directory |
-| `LDAP_USER_BASE_DN` | Yes | DN under which user entries live (used to build `uid=<username>,<USER_BASE_DN>`) |
-| `LDAP_ADMIN_GROUP_DN` | Yes | DN of the group whose members are allowed admin access |
-| `LDAP_GROUP_MEMBER_ATTR` | No | Attribute on the group entry that lists members (default: `memberUid`) |
-| `LDAP_REJECT_UNAUTHORIZED` | No | Set to `"false"` to skip TLS certificate validation (default: `"true"`) |
+| Variable                   | Required | Description                                                                                   |
+| -------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `LDAP_URL`                 | Yes      | LDAP server URL(s). Comma-separated for failover (e.g. `ldaps://ldap1:636,ldaps://ldap2:636`) |
+| `LDAP_BASE_DN`             | Yes      | Base DN for the directory                                                                     |
+| `LDAP_USER_BASE_DN`        | Yes      | DN under which user entries live (used to build `uid=<username>,<USER_BASE_DN>`)              |
+| `LDAP_ADMIN_GROUP_DN`      | Yes      | DN of the group whose members are allowed admin access                                        |
+| `LDAP_GROUP_MEMBER_ATTR`   | No       | Attribute on the group entry that lists members (default: `memberUid`)                        |
+| `LDAP_REJECT_UNAUTHORIZED` | No       | Set to `"false"` to skip TLS certificate validation (default: `"true"`)                       |
 
 No database seeding required — admin access is determined by LDAP group membership.
 
@@ -38,55 +38,60 @@ No database seeding required — admin access is determined by LDAP group member
 
 ## Dashboard Tabs
 
-| Tab | Description |
-|-----|-------------|
-| 🔑 API Keys | Create / delete client API keys. Key shown once with copy button; list shows first-5-char prefix + masked remainder. |
-| 👤 Users | List all users with registration status. Approve pending users or delete any user. |
-| 📱 Devices | Devices grouped by user. Approve pending devices or revoke any device. |
-| 📧 Emails | Log of every outgoing email (registration approval, support, account deletion). Filter by type. Approve / reject users inline from registration emails. |
+| Tab         | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🔑 API Keys | Create / delete client API keys. Key shown once with copy button; list shows first-5-char prefix + masked remainder.                                    |
+| 👤 Users    | List all users with registration status. Approve pending users or delete any user.                                                                      |
+| 📱 Devices  | Devices grouped by user. Approve pending devices or revoke any device.                                                                                  |
+| 📧 Emails   | Log of every outgoing email (registration approval, support, account deletion). Filter by type. Approve / reject users inline from registration emails. |
 
 ## REST API Reference
 
 All endpoints require `Authorization: Bearer <token>` except login.
 
 ### Auth
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| POST | `/api/admin/auth` | `{ username, password }` | Login → `{ token }` |
-| GET | `/api/admin/verify` | — | Check session validity |
-| POST | `/api/admin/logout` | — | Destroy session |
+
+| Method | Path                | Body                     | Description            |
+| ------ | ------------------- | ------------------------ | ---------------------- |
+| POST   | `/api/admin/auth`   | `{ username, password }` | Login → `{ token }`    |
+| GET    | `/api/admin/verify` | —                        | Check session validity |
+| POST   | `/api/admin/logout` | —                        | Destroy session        |
 
 ### API Keys
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| GET | `/api/admin/api-keys/list` | — | List all client keys (prefix only) |
-| POST | `/api/admin/api-keys/create` | `{ clientId }` | Create key → returns plain key once |
-| DELETE | `/api/admin/api-keys/delete` | `{ clientId }` | Delete a key |
+
+| Method | Path                         | Body           | Description                         |
+| ------ | ---------------------------- | -------------- | ----------------------------------- |
+| GET    | `/api/admin/api-keys/list`   | —              | List all client keys (prefix only)  |
+| POST   | `/api/admin/api-keys/create` | `{ clientId }` | Create key → returns plain key once |
+| DELETE | `/api/admin/api-keys/delete` | `{ clientId }` | Delete a key                        |
 
 ### Users
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| GET | `/api/admin/users/list` | — | List all users |
-| POST | `/api/admin/users/approve` | `{ userId }` | Approve user + all devices |
-| POST | `/api/admin/users/delete` | `{ userId }` | Delete user + all data |
+
+| Method | Path                       | Body         | Description                |
+| ------ | -------------------------- | ------------ | -------------------------- |
+| GET    | `/api/admin/users/list`    | —            | List all users             |
+| POST   | `/api/admin/users/approve` | `{ userId }` | Approve user + all devices |
+| POST   | `/api/admin/users/delete`  | `{ userId }` | Delete user + all data     |
 
 ### Devices
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| GET | `/api/admin/devices/list` | — | List all devices |
-| POST | `/api/admin/devices/approve` | `{ userId, deviceUUID }` | Approve one device |
-| POST | `/api/admin/devices/revoke` | `{ userId, deviceUUID }` | Remove one device |
+
+| Method | Path                         | Body                     | Description        |
+| ------ | ---------------------------- | ------------------------ | ------------------ |
+| GET    | `/api/admin/devices/list`    | —                        | List all devices   |
+| POST   | `/api/admin/devices/approve` | `{ userId, deviceUUID }` | Approve one device |
+| POST   | `/api/admin/devices/revoke`  | `{ userId, deviceUUID }` | Remove one device  |
 
 ### Emails
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| GET | `/api/admin/emails/list` | — | Last 200 emails (newest first) |
+
+| Method | Path                     | Body | Description                    |
+| ------ | ------------------------ | ---- | ------------------------------ |
+| GET    | `/api/admin/emails/list` | —    | Last 200 emails (newest first) |
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `server/adminAuth.js` | LDAP bind + group membership check, session store, middleware |
-| `server/adminApi.js` | All REST endpoints |
-| `server/templates/admin.js` | Self-contained React SPA (served as HTML) |
-| `utils/api/emailLog.js` | `EmailLog` Mongo collection |
+| File                        | Purpose                                                       |
+| --------------------------- | ------------------------------------------------------------- |
+| `server/adminAuth.js`       | LDAP bind + group membership check, session store, middleware |
+| `server/adminApi.js`        | All REST endpoints                                            |
+| `server/templates/admin.js` | Self-contained React SPA (served as HTML)                     |
+| `utils/api/emailLog.js`     | `EmailLog` Mongo collection                                   |

--- a/server/adminAuth.js
+++ b/server/adminAuth.js
@@ -147,6 +147,34 @@ const escapeLdapFilter = (value) =>
     (ch) => "\\" + ch.charCodeAt(0).toString(16).padStart(2, "0"),
   );
 
+/**
+ * Build a group-membership filter that matches all common LDAP group schemes:
+ *   - posixGroup           → memberUid    = <username>   (bare uid)
+ *   - groupOfNames         → member       = <userDn>     (full DN)
+ *   - groupOfUniqueNames   → uniqueMember = <userDn>     (full DN)
+ *
+ * Directories differ on which RDN the member DN uses, so we match both the
+ * "uid=<user>,<base>" and "cn=<user>,<base>" forms (e.g. authentik lists
+ * members as "cn=<user>,ou=users,..."). The configured
+ * LDAP_GROUP_MEMBER_ATTR (default "memberUid") is always included so an
+ * explicit override still works.
+ */
+const buildMembershipFilter = (cfg, username) => {
+  const safeUser = escapeLdapFilter(username);
+  const base = cfg.userBaseDn || "";
+  const uidDn = escapeLdapFilter(`uid=${username},${base}`);
+  const cnDn = escapeLdapFilter(`cn=${username},${base}`);
+  const clauses = new Set([
+    `(${cfg.groupMemberAttr}=${safeUser})`,
+    `(memberUid=${safeUser})`,
+    `(member=${uidDn})`,
+    `(member=${cnDn})`,
+    `(uniqueMember=${uidDn})`,
+    `(uniqueMember=${cnDn})`,
+  ]);
+  return `(&(objectClass=*)(|${[...clauses].join("")}))`;
+};
+
 /** Build a human-readable error message from an ldapjs error */
 const ldapErrorMessage = (err) => {
   // ldapjs puts the error type in err.name (e.g. "InvalidCredentialsError")
@@ -428,8 +456,7 @@ const ldapSearchOne = (client, baseDn, filter, scope = "sub") =>
  * negatives for anonymous searches (the dev server is affected).
  */
 const ldapSearchCli = async (cfg, username) => {
-  const safeUser = escapeLdapFilter(username);
-  const filter = `(&(objectClass=*)(${cfg.groupMemberAttr}=${safeUser}))`;
+  const filter = buildMembershipFilter(cfg, username);
 
   // Use service-account credentials when configured; otherwise fall back to
   // a simple anonymous ("-x") search for backward compatibility.
@@ -494,11 +521,11 @@ const ldapSearchCli = async (cfg, username) => {
 
 /**
  * Check whether `username` is a member of the admin group.
- * Searches the group entry for the memberUid (or custom attr) matching the username.
+ * Searches the group entry for any of the common membership attributes
+ * (memberUid with the bare uid, or member/uniqueMember with the full DN).
  */
 const isGroupMember = async (client, cfg, username) => {
-  const safeUser = escapeLdapFilter(username);
-  const filter = `(&(objectClass=*)(${cfg.groupMemberAttr}=${safeUser}))`;
+  const filter = buildMembershipFilter(cfg, username);
   console.log(
     `${LOG_PREFIX} Checking group membership: group="${cfg.adminGroupDn}" attr=${cfg.groupMemberAttr} user="${username}"`,
   );


### PR DESCRIPTION
## Problem

Admin login failed in production with `[NOT_IN_GROUP] User is not a member of the admin group` for valid admins.

Root cause: the group membership check only searched `(memberUid=<user>)`. Our directory (authentik) lists members on the `tfa-admins` group as:

```
member: cn=aabrol,ou=users,dc=cluster,dc=mieweb,dc=org
```

i.e. a `groupOfNames`/`groupOfUniqueNames` scheme using `member` with the full `cn=` DN — never `memberUid`. The search returned 0 entries, so every admin was rejected.

## Fix

`buildMembershipFilter` now ORs all common schemes, derived from `LDAP_USER_BASE_DN`:

```
(&(objectClass=*)(|
  (memberUid=<user>)
  (member=uid=<user>,<base>)
  (member=cn=<user>,<base>)
  (uniqueMember=uid=<user>,<base>)
  (uniqueMember=cn=<user>,<base>)
))
```

- Applied to both the in-process ldapjs search and the `ldapsearch` CLI fallback.
- Still honors an explicit `LDAP_GROUP_MEMBER_ATTR` override.
- Verified against prod LDAP: this filter returns the group (`numEntries: 1`).

Docs updated to the correct `ou=users` / `ou=groups` DNs.

## Note (ops, not code)

Production also had a stale process: the running service predated the corrected `LDAP_ADMIN_GROUP_DN` (missing `ou=groups`). The env file on disk is already correct — `systemctl restart mieauth` is required after deploying this build.