### PR TITLE
fix(admin-auth): configurable user RDN attribute for LDAP bind

### DIFF
--- a/docs/ADMIN_DASHBOARD.md
+++ b/docs/ADMIN_DASHBOARD.md
@@ -12,19 +12,22 @@ export LDAP_URL="ldaps://ldap1.cluster.mieweb.org:636,ldaps://ldap2.cluster.miew
 export LDAP_BASE_DN="dc=cluster,dc=mieweb,dc=org"
 export LDAP_USER_BASE_DN="ou=users,dc=cluster,dc=mieweb,dc=org"
 export LDAP_ADMIN_GROUP_DN="cn=tfa-admins,ou=groups,dc=cluster,dc=mieweb,dc=org"
+# optional – user RDN attribute, defaults to "uid" (authentik uses "cn")
+# export LDAP_USER_RDN_ATTR="cn"
 # optional – defaults to "memberUid"
 # export LDAP_GROUP_MEMBER_ATTR="memberUid"
 export LDAP_REJECT_UNAUTHORIZED="false"
 ```
 
-| Variable                   | Required | Description                                                                                   |
-| -------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `LDAP_URL`                 | Yes      | LDAP server URL(s). Comma-separated for failover (e.g. `ldaps://ldap1:636,ldaps://ldap2:636`) |
-| `LDAP_BASE_DN`             | Yes      | Base DN for the directory                                                                     |
-| `LDAP_USER_BASE_DN`        | Yes      | DN under which user entries live (used to build `uid=<username>,<USER_BASE_DN>`)              |
-| `LDAP_ADMIN_GROUP_DN`      | Yes      | DN of the group whose members are allowed admin access                                        |
-| `LDAP_GROUP_MEMBER_ATTR`   | No       | Attribute on the group entry that lists members (default: `memberUid`)                        |
-| `LDAP_REJECT_UNAUTHORIZED` | No       | Set to `"false"` to skip TLS certificate validation (default: `"true"`)                       |
+| Variable                   | Required | Description                                                                                     |
+| -------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `LDAP_URL`                 | Yes      | LDAP server URL(s). Comma-separated for failover (e.g. `ldaps://ldap1:636,ldaps://ldap2:636`)   |
+| `LDAP_BASE_DN`             | Yes      | Base DN for the directory                                                                       |
+| `LDAP_USER_BASE_DN`        | Yes      | DN under which user entries live (used to build `<rdn>=<username>,<USER_BASE_DN>`)              |
+| `LDAP_USER_RDN_ATTR`       | No       | RDN attribute for user entries, used to build the bind DN (default: `uid`; authentik uses `cn`) |
+| `LDAP_ADMIN_GROUP_DN`      | Yes      | DN of the group whose members are allowed admin access                                          |
+| `LDAP_GROUP_MEMBER_ATTR`   | No       | Attribute on the group entry that lists members (default: `memberUid`)                          |
+| `LDAP_REJECT_UNAUTHORIZED` | No       | Set to `"false"` to skip TLS certificate validation (default: `"true"`)                         |
 
 No database seeding required — admin access is determined by LDAP group membership.
 

--- a/server/adminAuth.js
+++ b/server/adminAuth.js
@@ -70,6 +70,10 @@ const ldapConfig = () => ({
   url: process.env.LDAP_URL, // raw value for config-check logging
   baseDn: process.env.LDAP_BASE_DN,
   userBaseDn: process.env.LDAP_USER_BASE_DN,
+  // RDN attribute for user entries — used to build the bind DN
+  // "<attr>=<username>,<userBaseDn>". Defaults to "uid"; directories such as
+  // authentik use "cn" (e.g. cn=aabrol,ou=users,...).
+  userRdnAttr: process.env.LDAP_USER_RDN_ATTR || "uid",
   adminGroupDn: process.env.LDAP_ADMIN_GROUP_DN,
   groupMemberAttr: process.env.LDAP_GROUP_MEMBER_ATTR || "memberUid",
   // Optional service-account credentials for the pre-auth group-membership
@@ -569,7 +573,7 @@ export const validateCredentials = async (username, password) => {
     throw err;
   }
 
-  const userDn = `uid=${username},${cfg.userBaseDn}`;
+  const userDn = `${cfg.userRdnAttr}=${username},${cfg.userBaseDn}`;
   console.log(`${LOG_PREFIX} ── Authenticating user "${username}" ──`);
   console.log(`${LOG_PREFIX} User DN: ${userDn}`);
   console.log(`${LOG_PREFIX} Admin group: ${cfg.adminGroupDn}`);


### PR DESCRIPTION
## Problem

Follow-up to #391. After the group-membership fix landed, admin login still failed at the password-bind step:

```
Binding as "uid=aabrol,ou=users,..."
Bind FAILED (INSUFFICIENT_ACCESS): Insufficient Access Rights
```

Root cause: our directory (authentik) uses **cn** as the user RDN — the real entry is `cn=aabrol,ou=users,...`, not `uid=aabrol,...`. The code hard-coded the bind DN as `uid=<username>,<base>`, so it bound to a non-existent DN.

Verified manually: binding as `cn=aabrol,ou=users,...` succeeds (`result: 0`).

## Fix

- Add `LDAP_USER_RDN_ATTR` env var (default `uid`).
- Build the bind DN as `<rdn>=<username>,<userBaseDn>`.
- Set `LDAP_USER_RDN_ATTR=cn` for authentik directories.
- Membership filter already ORs both `cn=`/`uid=` forms, so no change needed there.

Docs updated.

## Ops

Add to the prod env file and redeploy/restart:
```sh
export LDAP_USER_RDN_ATTR="cn"
```