### PR TITLE
Skip TestFlight export-compliance prompt for iOS builds

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -33,6 +33,14 @@ App.appendToConfig(`
   </edit-config>
 `);
 
+// App uses only standard HTTPS/TLS (exempt encryption), so declare it here to
+// skip the TestFlight export-compliance prompt on every upload.
+App.appendToConfig(`
+  <edit-config target="ITSAppUsesNonExemptEncryption" file="*-Info.plist" mode="overwrite">
+    <false/>
+  </edit-config>
+`);
+
 // Add necessary Android permissions for Camera
 App.appendToConfig(`
   <config-file target="AndroidManifest.xml" parent="/*">


### PR DESCRIPTION
Sets `ITSAppUsesNonExemptEncryption=false` in `Info.plist` (via `mobile-config.js`) so App Store Connect stops showing **Missing Compliance** and no longer requires a manual export-compliance answer on every TestFlight upload.

The app uses only standard HTTPS/TLS, which is exempt from export documentation.

Verified with a full `meteor build` (Meteor 3.4): the exported `ios/project/MIEAuth/MIEAuth-Info.plist` contains `ITSAppUsesNonExemptEncryption = false` (real plist boolean, `plutil -lint` OK); the camera key is unaffected.

Closes #398