### PR TITLE
Fix biometric recovery after device restore

### DIFF
--- a/client/mobile/src/ui/Login.jsx
+++ b/client/mobile/src/ui/Login.jsx
@@ -190,7 +190,7 @@ export const LoginPage = ({ deviceDetails }) => {
         throw new Error("Biometric auth unavailable on this device.");
 
       await new Promise((resolve, reject) => {
-        Fingerprint.loadBiometricSecret(
+        window.Fingerprint.loadBiometricSecret(
           {
             description: "Authenticate to unlock MIE Auth",
             disableBackup: true,
@@ -228,6 +228,8 @@ export const LoginPage = ({ deviceDetails }) => {
                   _id: result._id,
                 });
                 navigate("/dashboard");
+              } else {
+                await new Promise((res) => Meteor.logout(res));
               }
               resolve();
             } catch (err) {

--- a/client/mobile/src/ui/Login.jsx
+++ b/client/mobile/src/ui/Login.jsx
@@ -3,12 +3,47 @@ import { useNavigate } from "react-router-dom";
 import { openSupportLink } from "../../../../utils/openExternal";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
+import { Random } from "meteor/random";
 import {
   Fingerprint as FingerprintIcon,
   KeyRound,
   AlertCircle,
 } from "lucide-react";
-import { Input, Button, Alert, AlertDescription } from "@mieweb/ui";
+import {
+  Input,
+  Button,
+  Alert,
+  AlertDescription,
+  Modal,
+  ModalBody,
+} from "@mieweb/ui";
+
+const BIOMETRIC_SECRET_NOT_FOUND = -113;
+const BIOMETRIC_RECOVERY_NEEDED_KEY = "biometricRecoveryNeeded";
+
+const isMissingBiometricSecret = (error) => {
+  if (Number(error?.code) === BIOMETRIC_SECRET_NOT_FOUND) return true;
+
+  const message = String(error?.message || error || "").toLowerCase();
+  return (
+    message.includes("item could not be found in the keychain") ||
+    message.includes("secret not found") ||
+    message.includes("no secret found")
+  );
+};
+
+const clearBiometricEnrollment = () => {
+  localStorage.removeItem("biometricsEnabled");
+  localStorage.removeItem("biometricUserId");
+};
+
+const setBiometricRecoveryNeeded = (isNeeded) => {
+  if (isNeeded) {
+    localStorage.setItem(BIOMETRIC_RECOVERY_NEEDED_KEY, "true");
+  } else {
+    localStorage.removeItem(BIOMETRIC_RECOVERY_NEEDED_KEY);
+  }
+};
 
 // ── Lock Screen (biometric auto-trigger) ────────────────────────────────────
 const LockScreen = ({
@@ -77,11 +112,19 @@ export const LoginPage = ({ deviceDetails }) => {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [checkingStatus, setCheckingStatus] = useState(false);
   const [showPinForm, setShowPinForm] = useState(false);
+  const [needsBiometricRecovery, setNeedsBiometricRecovery] = useState(
+    () => localStorage.getItem(BIOMETRIC_RECOVERY_NEEDED_KEY) === "true",
+  );
+  const [showRecoveryPrompt, setShowRecoveryPrompt] = useState(false);
+  const [isRecoveringBiometrics, setIsRecoveringBiometrics] = useState(false);
+  const [recoveryError, setRecoveryError] = useState("");
   const navigate = useNavigate();
   const biometricTriggered = useRef(false);
 
   // Determine if biometric credentials exist
-  const hasBiometricCredentials = !!localStorage.getItem("biometricUserId");
+  const hasBiometricCredentials =
+    localStorage.getItem("biometricsEnabled") === "true" ||
+    !!localStorage.getItem("biometricUserId");
 
   // ── Connection monitor ──────────────────────────────────────────────────
   useEffect(() => {
@@ -99,34 +142,41 @@ export const LoginPage = ({ deviceDetails }) => {
   }, []);
 
   // ── Registration check helper ───────────────────────────────────────────
-  const checkRegistrationStatus = async (userId, emailAddress) => {
-    setCheckingStatus(true);
-    try {
-      const result = await Meteor.callAsync("users.checkRegistrationStatus", {
-        userId,
-        email: emailAddress,
-      });
-      if (!result?.status)
-        throw new Error("Failed to retrieve registration status");
+  const checkRegistrationStatus = useCallback(
+    async (userId, emailAddress) => {
+      setCheckingStatus(true);
+      try {
+        const result = await Meteor.callAsync("users.checkRegistrationStatus", {
+          userId,
+          email: emailAddress,
+        });
+        if (!result?.status)
+          throw new Error("Failed to retrieve registration status");
 
-      if (result.status !== "approved") {
-        setError("Your account is pending approval by an administrator.");
-        navigate("/pending-registration");
+        if (result.status !== "approved") {
+          setError("Your account is pending approval by an administrator.");
+          navigate("/pending-registration");
+          return false;
+        }
+        return true;
+      } catch (err) {
+        setError(
+          err.reason || err.message || "Failed to verify account status",
+        );
         return false;
+      } finally {
+        setCheckingStatus(false);
       }
-      return true;
-    } catch (err) {
-      setError(err.reason || err.message || "Failed to verify account status");
-      return false;
-    } finally {
-      setCheckingStatus(false);
-    }
-  };
+    },
+    [navigate],
+  );
 
   // ── Biometric login (reusable) ──────────────────────────────────────────
   const handleBiometricLogin = useCallback(async () => {
-    const biometricUserId = localStorage.getItem("biometricUserId");
-    if (!biometricUserId) {
+    const hasEnrollment =
+      localStorage.getItem("biometricsEnabled") === "true" ||
+      !!localStorage.getItem("biometricUserId");
+    if (!hasEnrollment) {
       // No credentials stored – fall back to PIN form
       setShowPinForm(true);
       return;
@@ -145,11 +195,11 @@ export const LoginPage = ({ deviceDetails }) => {
             description: "Authenticate to unlock MIE Auth",
             disableBackup: true,
           },
-          async () => {
+          async (biometricSecret) => {
             try {
               const result = await Meteor.callAsync(
                 "users.loginWithBiometric",
-                biometricUserId,
+                biometricSecret,
               );
               if (!result?._id)
                 throw new Error("Biometric authentication failed");
@@ -168,6 +218,10 @@ export const LoginPage = ({ deviceDetails }) => {
                 result.email,
               );
               if (isApproved) {
+                localStorage.setItem("biometricsEnabled", "true");
+                localStorage.removeItem("biometricUserId");
+                setBiometricRecoveryNeeded(false);
+                setNeedsBiometricRecovery(false);
                 Session.set("userProfile", {
                   email: result.email,
                   username: result.username,
@@ -185,12 +239,90 @@ export const LoginPage = ({ deviceDetails }) => {
         );
       });
     } catch (err) {
-      setError(err.message || "Biometric login failed. Use PIN instead.");
-      // Don't auto-open PIN – let user decide
+      if (isMissingBiometricSecret(err)) {
+        clearBiometricEnrollment();
+        setBiometricRecoveryNeeded(true);
+        setNeedsBiometricRecovery(true);
+        setShowPinForm(true);
+        setError(
+          "Your biometric setup is no longer available on this device. Sign in with your PIN to set it up again.",
+        );
+      } else {
+        setError(err.message || "Biometric login failed. Use PIN instead.");
+      }
     } finally {
       setIsLoggingIn(false);
     }
-  }, [navigate]);
+  }, [checkRegistrationStatus, navigate]);
+
+  const finishPinLogin = (userId) => {
+    Session.set("userProfile", { email, _id: userId });
+    localStorage.setItem("lastLoggedInEmail", email);
+
+    if (needsBiometricRecovery || !hasBiometricCredentials) {
+      setRecoveryError("");
+      setShowRecoveryPrompt(true);
+      return;
+    }
+
+    navigate("/dashboard");
+  };
+
+  const registerRecoveredBiometrics = () => {
+    if (!window.Fingerprint) {
+      setRecoveryError(
+        "Biometric authentication is unavailable on this device.",
+      );
+      return;
+    }
+
+    if (!deviceDetails) {
+      setRecoveryError("Device information is unavailable. Please try again.");
+      return;
+    }
+
+    setIsRecoveringBiometrics(true);
+    setRecoveryError("");
+    const biometricSecret = Random.secret(32);
+
+    window.Fingerprint.registerBiometricSecret(
+      {
+        description: "Set up biometric login for MIE Auth",
+        secret: biometricSecret,
+        invalidateOnEnrollment: true,
+        disableBackup: true,
+      },
+      async () => {
+        try {
+          await Meteor.callAsync("users.rotateBiometricSecret", {
+            deviceUUID: deviceDetails,
+            biometricSecret,
+          });
+          localStorage.setItem("biometricsEnabled", "true");
+          localStorage.removeItem("biometricUserId");
+          setBiometricRecoveryNeeded(false);
+          setNeedsBiometricRecovery(false);
+          setShowRecoveryPrompt(false);
+          navigate("/dashboard");
+        } catch (err) {
+          clearBiometricEnrollment();
+          setRecoveryError(
+            err.reason ||
+              err.message ||
+              "Unable to finish biometric setup. Please try again.",
+          );
+        } finally {
+          setIsRecoveringBiometrics(false);
+        }
+      },
+      (err) => {
+        setRecoveryError(
+          err?.message || "Unable to register biometrics. Please try again.",
+        );
+        setIsRecoveringBiometrics(false);
+      },
+    );
+  };
 
   // ── Auto-trigger biometrics on mount for returning users ────────────────
   useEffect(() => {
@@ -240,9 +372,7 @@ export const LoginPage = ({ deviceDetails }) => {
 
       const isApproved = await checkRegistrationStatus(userId, email);
       if (isApproved) {
-        Session.set("userProfile", { email, _id: userId });
-        localStorage.setItem("lastLoggedInEmail", email);
-        navigate("/dashboard");
+        finishPinLogin(userId);
       } else {
         Meteor.logout();
       }
@@ -378,6 +508,61 @@ export const LoginPage = ({ deviceDetails }) => {
           </Button>
         )}
       </div>
+
+      <Modal
+        open={showRecoveryPrompt}
+        onOpenChange={(open) => {
+          if (!open && !isRecoveringBiometrics) {
+            setShowRecoveryPrompt(false);
+            navigate("/dashboard");
+          }
+        }}
+        size="sm"
+      >
+        <ModalBody className="text-center space-y-4">
+          <div className="mx-auto w-14 h-14 bg-primary/10 rounded-2xl flex items-center justify-center">
+            <FingerprintIcon className="h-7 w-7 text-primary" />
+          </div>
+          <div>
+            <h2 className="text-lg font-bold text-foreground">
+              {needsBiometricRecovery
+                ? "Set Up Biometrics Again"
+                : "Set Up Biometrics"}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {needsBiometricRecovery
+                ? "Your previous biometric credential was tied to your old device. Create a new credential for this device now."
+                : "Enable biometric login for faster, secure access on this device."}
+            </p>
+          </div>
+          {recoveryError && (
+            <Alert variant="danger" icon={<AlertCircle className="h-4 w-4" />}>
+              <AlertDescription>{recoveryError}</AlertDescription>
+            </Alert>
+          )}
+          <Button
+            onClick={registerRecoveredBiometrics}
+            disabled={isRecoveringBiometrics}
+            isLoading={isRecoveringBiometrics}
+            loadingText="Setting Up…"
+            fullWidth
+            leftIcon={<FingerprintIcon className="h-5 w-5" />}
+          >
+            Set Up Biometrics
+          </Button>
+          <Button
+            onClick={() => {
+              setShowRecoveryPrompt(false);
+              navigate("/dashboard");
+            }}
+            disabled={isRecoveringBiometrics}
+            variant="secondary"
+            fullWidth
+          >
+            Skip for Now
+          </Button>
+        </ModalBody>
+      </Modal>
     </div>
   );
 };

--- a/client/mobile/src/ui/Modal/BiometricRegistrationModal.jsx
+++ b/client/mobile/src/ui/Modal/BiometricRegistrationModal.jsx
@@ -47,7 +47,8 @@ const BiometricRegistrationModal = ({
   const handleSuccess = () => {
     setStatus("success");
     localStorage.setItem("biometricsEnabled", "true");
-    localStorage.setItem("biometricUserId", userData?.biometricSecret);
+    localStorage.removeItem("biometricUserId");
+    localStorage.removeItem("biometricRecoveryNeeded");
     setTimeout(() => {
       onClose();
       onComplete(true);

--- a/tests/main.js
+++ b/tests/main.js
@@ -294,6 +294,106 @@ describe("meteor-app", function () {
       });
     });
 
+    describe("Biometric credential recovery", function () {
+      const { DeviceDetails } = require("../utils/api/deviceDetails");
+      let userId;
+
+      beforeEach(async function () {
+        await Meteor.users.removeAsync({});
+        await DeviceDetails.removeAsync({});
+        userId = await Accounts.createUserAsync({
+          email: "biometric-recovery@example.com",
+          username: "biometric-recovery",
+          password: "123456",
+        });
+        await DeviceDetails.insertAsync({
+          userId,
+          email: "biometric-recovery@example.com",
+          username: "biometric-recovery",
+          devices: [
+            {
+              deviceUUID: "approved-device",
+              biometricSecret: "old-secret",
+              deviceRegistrationStatus: "approved",
+            },
+            {
+              deviceUUID: "pending-device",
+              biometricSecret: "pending-secret",
+              deviceRegistrationStatus: "pending",
+            },
+          ],
+        });
+      });
+
+      it("rotates the secret for the authenticated approved device", async function () {
+        const handler =
+          Meteor.server.method_handlers["users.rotateBiometricSecret"];
+        const result = await handler.apply({ userId, connection: null }, [
+          {
+            deviceUUID: "approved-device",
+            biometricSecret: "new-secret",
+          },
+        ]);
+
+        const userDoc = await DeviceDetails.findOneAsync({ userId });
+        const approvedDevice = userDoc.devices.find(
+          (device) => device.deviceUUID === "approved-device",
+        );
+        assert.deepStrictEqual(result, { success: true });
+        assert.strictEqual(approvedDevice.biometricSecret, "new-secret");
+      });
+
+      it("rejects rotation without an authenticated user", async function () {
+        const handler =
+          Meteor.server.method_handlers["users.rotateBiometricSecret"];
+
+        await assert.rejects(
+          handler.apply({ userId: null, connection: null }, [
+            {
+              deviceUUID: "approved-device",
+              biometricSecret: "new-secret",
+            },
+          ]),
+          (error) => error.error === "not-authorized",
+        );
+      });
+
+      it("rejects rotation for an unapproved device", async function () {
+        const handler =
+          Meteor.server.method_handlers["users.rotateBiometricSecret"];
+
+        await assert.rejects(
+          handler.apply({ userId, connection: null }, [
+            {
+              deviceUUID: "pending-device",
+              biometricSecret: "new-secret",
+            },
+          ]),
+          (error) => error.error === "device-not-approved",
+        );
+      });
+
+      it("rejects rotation for another user's device", async function () {
+        const otherUserId = await Accounts.createUserAsync({
+          email: "other-biometric-user@example.com",
+          username: "other-biometric-user",
+          password: "123456",
+        });
+        const handler =
+          Meteor.server.method_handlers["users.rotateBiometricSecret"];
+
+        await assert.rejects(
+          handler.apply({ userId: otherUserId, connection: null }, [
+            {
+              deviceUUID: "approved-device",
+              biometricSecret: "new-secret",
+            },
+          ]),
+          (error) => error.error === "device-not-approved",
+        );
+      });
+    });
+
     describe("Error Template with Specific Reasons", function () {
       const { errorTemplate } = require("../server/templates/email");
 

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -47,6 +47,72 @@ if (Meteor.isServer) {
 // Define methods for DeviceDetails
 Meteor.methods({
   /**
+   * Replace the biometric credential for the authenticated user's current
+   * approved device after PIN-based recovery.
+   * @param {Object} options - Current device UUID and replacement secret
+   * @returns {Object} Rotation result
+   */
+  async "users.rotateBiometricSecret"(options) {
+    check(options, {
+      deviceUUID: String,
+      biometricSecret: String,
+    });
+
+    if (!this.userId) {
+      throw new Meteor.Error(
+        "not-authorized",
+        "You must sign in before setting up biometrics",
+      );
+    }
+
+    const { deviceUUID, biometricSecret } = options;
+    const userDoc = await DeviceDetails.findOneAsync({
+      userId: this.userId,
+      devices: {
+        $elemMatch: {
+          deviceUUID,
+          deviceRegistrationStatus: "approved",
+        },
+      },
+    });
+
+    if (!userDoc) {
+      throw new Meteor.Error(
+        "device-not-approved",
+        "This device is not approved for biometric login",
+      );
+    }
+
+    const updated = await DeviceDetails.updateAsync(
+      {
+        userId: this.userId,
+        devices: {
+          $elemMatch: {
+            deviceUUID,
+            deviceRegistrationStatus: "approved",
+          },
+        },
+      },
+      {
+        $set: {
+          "devices.$.biometricSecret": biometricSecret,
+          "devices.$.lastUpdated": new Date(),
+          lastUpdated: new Date(),
+        },
+      },
+    );
+
+    if (updated !== 1) {
+      throw new Meteor.Error(
+        "biometric-update-failed",
+        "Unable to update biometric credentials",
+      );
+    }
+
+    return { success: true };
+  },
+
+  /**
    * Upsert device details
    * @param {Object} data - Device details data
    * @returns {String} Generated appId


### PR DESCRIPTION
### https://www.youtube.com/shorts/CivVLwDxEqw

## Summary

- detect missing device-bound biometric secrets after an iCloud/device restore
- fall back to PIN and offer biometric re-enrollment after successful authentication
- persist recovery state across app restarts and skipped setup attempts
- rotate the approved device's server-side biometric credential securely
- use the secret returned by the native Keychain instead of a local-storage bearer secret
- remove biometric secrets from local storage while retaining a non-sensitive enrollment marker

## Testing

- reproduced the missing-Keychain state locally by resetting the iOS Simulator Keychain
- verified PIN fallback and biometric re-enrollment end-to-end in the simulator
- verified recovery remains available after closing/reopening or skipping setup
- added server tests for successful rotation, unauthenticated access, unapproved devices, and cross-user device access
- biometric recovery tests pass; full suite reports 77 passing and 6 pre-existing failures unrelated to this change

Fixes #404