### PR TITLE
fix: prevent mobile header from clipping greeting

### DIFF
--- a/client/mobile/src/ui/components/DashboardHeader.jsx
+++ b/client/mobile/src/ui/components/DashboardHeader.jsx
@@ -27,7 +27,7 @@ export const DashboardHeader = ({
   const iconLabel = "text-[9px] font-medium mt-0.5 leading-tight";
 
   return (
-    <header className="sticky top-0 z-50 bg-card shadow-sm isolate">
+    <header className="relative z-50 isolate bg-card shadow-sm sm:sticky sm:top-0">
       <div className="px-4 py-2.5">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Before


https://github.com/user-attachments/assets/1c045813-846f-4866-8ece-40048aaf3476


## After


https://github.com/user-attachments/assets/a35ed062-f3c2-42f1-b219-0513dc1f6b11



## Summary
- disable the sticky dashboard header on phone-sized viewports
- retain sticky header behavior on larger screens
- prevent the welcome greeting from scrolling behind the header on large iPhones

## Validation
- ESLint passed through the pre-commit hook
- `git diff --check` passed

Closes #375