### PR TITLE
feat: add test push notification button (mobile)

### DIFF
--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -113,6 +113,11 @@ const configurePushNotifications = () => {
       sound: true,
       priority: "high",
       foreground: true,
+      // Force the OS to display the notification banner even when the app is
+      // in the foreground (matches the Android `forceShow` behavior). Without
+      // this, iOS silently delivers foreground pushes to the JS handler with
+      // no visible banner.
+      forceShow: true,
       // Statically register the APPROVAL category so its action buttons are
       // rendered by the system — including when the notification is mirrored to
       // a paired Apple Watch. The watch only shows actions that come from a

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -113,11 +113,11 @@ const configurePushNotifications = () => {
       sound: true,
       priority: "high",
       foreground: true,
-      // Force the OS to display the notification banner even when the app is
-      // in the foreground (matches the Android `forceShow` behavior). Without
-      // this, iOS silently delivers foreground pushes to the JS handler with
-      // no visible banner.
-      forceShow: true,
+      // NOTE: `forceShow` must stay OFF. With forceShow the plugin only shows
+      // the OS banner for foreground pushes and does NOT dispatch them to the
+      // JS `notification` handler until tapped (see PushPlugin.m
+      // willPresentNotification), which breaks the auto-opening approve/reject
+      // actions modal. Foreground pushes are surfaced in-app instead.
       // Statically register the APPROVAL category so its action buttons are
       // rendered by the system — including when the notification is mirrored to
       // a paired Apple Watch. The watch only shows actions that come from a
@@ -219,6 +219,20 @@ const setupNotificationHandler = (push) => {
             );
           });
         }, 2000);
+      }
+
+      // Test notification received while the app is in the foreground.
+      // Foreground pushes are delivered straight to this handler (no OS
+      // banner, since forceShow is off), so surface an in-app toast that
+      // explains what happened instead of silently swallowing the push.
+      if (
+        additionalData.notificationType === "test" &&
+        additionalData.foreground
+      ) {
+        Session.set("testNotificationForeground", {
+          timestamp: new Date().getTime(),
+        });
+        return;
       }
 
       // Standard notification handling

--- a/client/mobile/src/ui/LandingPage.jsx
+++ b/client/mobile/src/ui/LandingPage.jsx
@@ -14,6 +14,7 @@ import { useSessionTimeout } from "./hooks/useSessionTimeout";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { ProfileSection } from "./components/ProfileSection";
 import { NotificationList } from "./components/NotificationList";
+import { TestNotificationButton } from "./components/TestNotificationButton";
 import Pagination from "./Pagination/Pagination";
 import ActionsModal from "./Modal/ActionsModal";
 import ResultModal from "./Modal/ResultModal";
@@ -219,6 +220,9 @@ export const LandingPage = () => {
             </Card>
           ))}
         </div>
+
+        {/* Test Push Notification */}
+        <TestNotificationButton />
 
         {/* Notifications */}
         <div className="space-y-4">

--- a/client/mobile/src/ui/LandingPage.jsx
+++ b/client/mobile/src/ui/LandingPage.jsx
@@ -14,7 +14,6 @@ import { useSessionTimeout } from "./hooks/useSessionTimeout";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { ProfileSection } from "./components/ProfileSection";
 import { NotificationList } from "./components/NotificationList";
-import { TestNotificationButton } from "./components/TestNotificationButton";
 import Pagination from "./Pagination/Pagination";
 import ActionsModal from "./Modal/ActionsModal";
 import ResultModal from "./Modal/ResultModal";
@@ -220,9 +219,6 @@ export const LandingPage = () => {
             </Card>
           ))}
         </div>
-
-        {/* Test Push Notification */}
-        <TestNotificationButton />
 
         {/* Notifications */}
         <div className="space-y-4">

--- a/client/mobile/src/ui/Toasters/SuccessToaster.jsx
+++ b/client/mobile/src/ui/Toasters/SuccessToaster.jsx
@@ -28,7 +28,10 @@ const SuccessToaster = ({ message, onClose, variant = "success" }) => {
           animate={{ x: 0 }}
           exit={{ x: "150%" }}
           transition={{ duration: 0.5, ease: "easeInOut" }}
-          className={`fixed top-5 right-5 ${bgColor} text-white px-4 py-2 rounded shadow-lg`}
+          // Offset by the device safe-area inset so the toast clears the iOS
+          // status bar / app header, and cap the width so long messages wrap
+          // instead of stretching across (and covering) the header controls.
+          className={`fixed right-4 top-[calc(env(safe-area-inset-top,0px)+4.5rem)] z-[60] max-w-[calc(100vw-2rem)] sm:max-w-sm ${bgColor} text-white text-sm px-4 py-2 rounded-lg shadow-lg`}
         >
           {message}
         </motion.div>

--- a/client/mobile/src/ui/Toasters/SuccessToaster.jsx
+++ b/client/mobile/src/ui/Toasters/SuccessToaster.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
-const SuccessToaster = ({ message, onClose }) => {
+const SuccessToaster = ({ message, onClose, variant = "success" }) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       onClose();
     }, 3000);
     return () => clearTimeout(timer);
   }, [onClose]);
+
+  const bgColor = variant === "error" ? "bg-red-500" : "bg-green-500";
 
   return (
     <AnimatePresence>
@@ -17,7 +19,7 @@ const SuccessToaster = ({ message, onClose }) => {
           animate={{ x: 0 }}
           exit={{ x: "150%" }}
           transition={{ duration: 0.5, ease: "easeInOut" }}
-          className="fixed top-5 right-5 bg-green-500 text-white px-4 py-2 rounded shadow-lg"
+          className={`fixed top-5 right-5 ${bgColor} text-white px-4 py-2 rounded shadow-lg`}
         >
           {message}
         </motion.div>

--- a/client/mobile/src/ui/Toasters/SuccessToaster.jsx
+++ b/client/mobile/src/ui/Toasters/SuccessToaster.jsx
@@ -1,13 +1,22 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
 const SuccessToaster = ({ message, onClose, variant = "success" }) => {
+  // Keep the latest onClose in a ref so the auto-close timer never depends on
+  // its identity. Callers pass inline lambdas that change on every render, so
+  // depending on onClose would restart the timer on unrelated re-renders.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Drive the auto-close timer off `message`: start it only when a toast is
+  // actually shown and restart it whenever the message changes.
   useEffect(() => {
+    if (!message) return undefined;
     const timer = setTimeout(() => {
-      onClose();
+      onCloseRef.current?.();
     }, 3000);
     return () => clearTimeout(timer);
-  }, [onClose]);
+  }, [message]);
 
   const bgColor = variant === "error" ? "bg-red-500" : "bg-green-500";
 

--- a/client/mobile/src/ui/components/DashboardHeader.jsx
+++ b/client/mobile/src/ui/components/DashboardHeader.jsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { openSupportLink } from "../../../../../utils/openExternal";
 import { Button, AppHeaderDivider } from "@mieweb/ui";
+import { TestNotificationButton } from "./TestNotificationButton";
 
 export const DashboardHeader = ({
   isDarkMode,
@@ -76,6 +77,7 @@ export const DashboardHeader = ({
               <HelpCircle className="h-[18px] w-[18px] text-muted-foreground" />
               <span className={`${iconLabel} text-muted-foreground`}>Help</span>
             </Button>
+            <TestNotificationButton />
             <AppHeaderDivider className="h-7" />
             <Button
               variant="ghost"

--- a/client/mobile/src/ui/components/TestNotificationButton.jsx
+++ b/client/mobile/src/ui/components/TestNotificationButton.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { Meteor } from "meteor/meteor";
+import { BellRing } from "lucide-react";
+import { Button, Card, CardContent } from "@mieweb/ui";
+import SuccessToaster from "../Toasters/SuccessToaster";
+
+/**
+ * Lets a signed-in user send a push notification to their own approved
+ * device(s) to verify that push delivery is working end-to-end.
+ */
+export const TestNotificationButton = () => {
+  const [isSending, setIsSending] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleSendTest = () => {
+    setErrorMessage("");
+    setSuccessMessage("");
+    setIsSending(true);
+
+    Meteor.call("notifications.sendTest", (error, result) => {
+      setIsSending(false);
+      if (error) {
+        setErrorMessage(
+          error.reason || "Could not send the test notification.",
+        );
+        return;
+      }
+      const count = result?.sent || 0;
+      setSuccessMessage(
+        `Test notification sent to ${count} device${count === 1 ? "" : "s"}.`,
+      );
+    });
+  };
+
+  return (
+    <>
+      <SuccessToaster
+        message={successMessage}
+        onClose={() => setSuccessMessage("")}
+      />
+      <Card>
+        <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">
+              Test push notifications
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Send a sample notification to your approved device to confirm
+              delivery is working.
+            </p>
+            {errorMessage && (
+              <p className="text-xs text-destructive mt-1">{errorMessage}</p>
+            )}
+          </div>
+          <Button
+            onClick={handleSendTest}
+            disabled={isSending}
+            aria-label="Send test notification"
+            className="shrink-0"
+          >
+            <BellRing className="h-4 w-4 mr-2" />
+            {isSending ? "Sending..." : "Send Test"}
+          </Button>
+        </CardContent>
+      </Card>
+    </>
+  );
+};

--- a/client/mobile/src/ui/components/TestNotificationButton.jsx
+++ b/client/mobile/src/ui/components/TestNotificationButton.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
 import { Meteor } from "meteor/meteor";
 import { BellRing } from "lucide-react";
-import { Button, Card, CardContent } from "@mieweb/ui";
+import { Button } from "@mieweb/ui";
 import SuccessToaster from "../Toasters/SuccessToaster";
 
 /**
- * Lets a signed-in user send a push notification to their own approved
- * device(s) to verify that push delivery is working end-to-end.
+ * Compact utility action (rendered in the dashboard header) that lets a
+ * signed-in user send a push notification to their own approved device(s)
+ * to verify that push delivery is working end-to-end.
  */
 export const TestNotificationButton = () => {
   const [isSending, setIsSending] = useState(false);
@@ -14,6 +15,7 @@ export const TestNotificationButton = () => {
   const [errorMessage, setErrorMessage] = useState("");
 
   const handleSendTest = () => {
+    if (isSending) return;
     setErrorMessage("");
     setSuccessMessage("");
     setIsSending(true);
@@ -39,31 +41,25 @@ export const TestNotificationButton = () => {
         message={successMessage}
         onClose={() => setSuccessMessage("")}
       />
-      <Card>
-        <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0">
-            <p className="text-sm font-semibold text-foreground">
-              Test push notifications
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Send a sample notification to your approved device to confirm
-              delivery is working.
-            </p>
-            {errorMessage && (
-              <p className="text-xs text-destructive mt-1">{errorMessage}</p>
-            )}
-          </div>
-          <Button
-            onClick={handleSendTest}
-            disabled={isSending}
-            aria-label="Send test notification"
-            className="shrink-0"
-          >
-            <BellRing className="h-4 w-4 mr-2" />
-            {isSending ? "Sending..." : "Send Test"}
-          </Button>
-        </CardContent>
-      </Card>
+      <SuccessToaster
+        message={errorMessage}
+        variant="error"
+        onClose={() => setErrorMessage("")}
+      />
+      <Button
+        variant="ghost"
+        onClick={handleSendTest}
+        disabled={isSending}
+        aria-label="Send test notification"
+        className="flex flex-col items-center justify-center py-1.5 px-2.5 rounded-xl h-auto"
+      >
+        <BellRing
+          className={`h-[18px] w-[18px] text-muted-foreground ${isSending ? "animate-pulse" : ""}`}
+        />
+        <span className="text-[9px] font-medium mt-0.5 leading-tight text-muted-foreground">
+          Test
+        </span>
+      </Button>
     </>
   );
 };

--- a/client/mobile/src/ui/components/TestNotificationButton.jsx
+++ b/client/mobile/src/ui/components/TestNotificationButton.jsx
@@ -1,30 +1,83 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Meteor } from "meteor/meteor";
+import { Session } from "meteor/session";
+import { useTracker } from "meteor/react-meteor-data";
 import { BellRing } from "lucide-react";
 import { Button } from "@mieweb/ui";
 import SuccessToaster from "../Toasters/SuccessToaster";
+
+const DELAY_OPTIONS = [
+  { label: "Send now", seconds: 0 },
+  { label: "Send in 5s", seconds: 5 },
+  { label: "Send in 10s", seconds: 10 },
+  { label: "Send in 30s", seconds: 30 },
+];
 
 /**
  * Compact utility action (rendered in the dashboard header) that lets a
  * signed-in user send a push notification to their own approved device(s)
  * to verify that push delivery is working end-to-end.
+ *
+ * Tapping the button opens a small menu to send the test push immediately or
+ * after a short delay. The delay lets the user background/close the app first
+ * so they can verify the system banner (background behavior); an immediate
+ * send while the app stays open is delivered in-app instead, since foreground
+ * pushes are routed to the JS handler rather than shown as an OS banner.
  */
 export const TestNotificationButton = () => {
   const [isSending, setIsSending] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const menuRef = useRef(null);
 
-  const handleSendTest = () => {
+  // A test push that arrives while the app is open is delivered straight to
+  // the JS notification handler (no OS banner). Surface it as an in-app toast
+  // that explains why no banner appeared.
+  const foregroundReceipt = useTracker(() =>
+    Session.get("testNotificationForeground"),
+  );
+  useEffect(() => {
+    if (!foregroundReceipt) return;
+    Session.set("testNotificationForeground", null);
+    setSuccessMessage(
+      "Test push received. The app was open, so it's shown here in-app — " +
+        "the OS only shows a banner when the app is in the background. " +
+        "Use a delayed send and close the app to test the banner.",
+    );
+  }, [foregroundReceipt]);
+
+  // Close the menu when tapping anywhere outside it.
+  useEffect(() => {
+    if (!isMenuOpen) return undefined;
+    const handlePointerDown = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setIsMenuOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isMenuOpen]);
+
+  const handleSendTest = (delaySeconds) => {
     if (isSending) return;
+    setIsMenuOpen(false);
     setErrorMessage("");
     setSuccessMessage("");
     setIsSending(true);
 
-    Meteor.call("notifications.sendTest", (error, result) => {
+    Meteor.call("notifications.sendTest", delaySeconds, (error, result) => {
       setIsSending(false);
       if (error) {
         setErrorMessage(
           error.reason || "Could not send the test notification.",
+        );
+        return;
+      }
+      if (result?.scheduled) {
+        setSuccessMessage(
+          `Test notification will be sent in ${result.delaySeconds}s — ` +
+            "close or background the app now to see the system banner.",
         );
         return;
       }
@@ -46,20 +99,42 @@ export const TestNotificationButton = () => {
         variant="error"
         onClose={() => setErrorMessage("")}
       />
-      <Button
-        variant="ghost"
-        onClick={handleSendTest}
-        disabled={isSending}
-        aria-label="Send test notification"
-        className="flex flex-col items-center justify-center py-1.5 px-2.5 rounded-xl h-auto"
-      >
-        <BellRing
-          className={`h-[18px] w-[18px] text-muted-foreground ${isSending ? "animate-pulse" : ""}`}
-        />
-        <span className="text-[9px] font-medium mt-0.5 leading-tight text-muted-foreground">
-          Test
-        </span>
-      </Button>
+      <div className="relative" ref={menuRef}>
+        <Button
+          variant="ghost"
+          onClick={() => setIsMenuOpen((open) => !open)}
+          disabled={isSending}
+          aria-label="Send test notification"
+          aria-expanded={isMenuOpen}
+          className="flex flex-col items-center justify-center py-1.5 px-2.5 rounded-xl h-auto"
+        >
+          <BellRing
+            className={`h-[18px] w-[18px] text-muted-foreground ${isSending ? "animate-pulse" : ""}`}
+          />
+          <span className="text-[9px] font-medium mt-0.5 leading-tight text-muted-foreground">
+            Test
+          </span>
+        </Button>
+        {isMenuOpen && (
+          <div className="absolute right-0 top-full mt-1 z-50 w-44 rounded-xl border border-border bg-background shadow-lg py-1">
+            {DELAY_OPTIONS.map(({ label, seconds }) => (
+              <button
+                key={seconds}
+                type="button"
+                onClick={() => handleSendTest(seconds)}
+                className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-muted"
+              >
+                {label}
+                {seconds > 0 && (
+                  <span className="block text-[10px] text-muted-foreground">
+                    Close the app to see the banner
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </>
   );
 };

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -80,13 +80,22 @@ export const sendNotification = async (fcmToken, title, body, data = {}) => {
             },
             badge: 1,
             sound: "default",
-            category: APPROVAL_CATEGORY_ID,
             "content-available": 1,
             "mutable-content": 1,
           },
         },
       },
     };
+
+    // Attach the iOS approval category — which renders the Approve/Reject
+    // action buttons, including when the push is mirrored to a paired Apple
+    // Watch — only for notifications that actually carry approval `actions`.
+    // Informational pushes (e.g. the test notification) omit `actions`, so they
+    // stay plain and non-actionable instead of surfacing Approve/Reject on
+    // iOS/watchOS.
+    if (stringifiedData.actions) {
+      message.apns.payload.aps.category = APPROVAL_CATEGORY_ID;
+    }
 
     // Only include title and body in data payload if they are not empty
     // Empty title/body indicates a silent background notification (for Android)

--- a/server/main.js
+++ b/server/main.js
@@ -2142,6 +2142,81 @@ Meteor.methods({
   },
 
   /**
+   * Send a test push notification to the signed-in user's own approved
+   * device(s) so they can verify push delivery is working end-to-end.
+   *
+   * Uses this.userId (never a client-supplied id) so a caller can only ever
+   * test their own devices. The payload is intentionally non-actionable —
+   * appId, notificationId and actions are omitted so the client treats it as
+   * a plain informational notification, not an approval request.
+   *
+   * @returns {{ sent: Number }} Number of devices the push reached
+   */
+  "notifications.sendTest": async function () {
+    const userId = this.userId;
+    if (!userId) {
+      throw new Meteor.Error(
+        "not-authorized",
+        "You must be signed in to send a test notification.",
+      );
+    }
+
+    let fcmTokens = [];
+    try {
+      fcmTokens = await Meteor.callAsync(
+        "deviceDetails.getApprovedFCMTokensByUserId",
+        userId,
+      );
+    } catch (error) {
+      // The lookup throws "invalid-username" when the user has no device
+      // document at all; treat that the same as having no approved devices.
+      if (error.error !== "invalid-username") {
+        throw error;
+      }
+    }
+
+    const validTokens = (fcmTokens || []).filter(Boolean);
+    if (validTokens.length === 0) {
+      throw new Meteor.Error(
+        "no-devices",
+        "No approved devices found. Register and get approved on a device first.",
+      );
+    }
+
+    const notificationData = {
+      messageFrom: "mie",
+      notificationType: "test",
+      isDismissal: "false",
+      isSync: "false",
+    };
+
+    const results = await Promise.allSettled(
+      validTokens.map((token) =>
+        sendNotification(
+          token,
+          "Test Notification",
+          "Your push notifications are working correctly.",
+          notificationData,
+        ),
+      ),
+    );
+
+    // sendNotification resolves with a message id on success and null when
+    // Firebase is not initialised, so only count deliveries with a real id.
+    const sent = results.filter(
+      (r) => r.status === "fulfilled" && r.value,
+    ).length;
+    if (sent === 0) {
+      throw new Meteor.Error(
+        "notification-failed",
+        "Failed to deliver the test notification to any device.",
+      );
+    }
+
+    return { sent };
+  },
+
+  /**
    * Admin approves or rejects first device
    *
    * @param {Object} options - Approval details

--- a/server/main.js
+++ b/server/main.js
@@ -2150,9 +2150,21 @@ Meteor.methods({
    * appId, notificationId and actions are omitted so the client treats it as
    * a plain informational notification, not an approval request.
    *
-   * @returns {{ sent: Number }} Number of devices the push reached
+   * @param {Number} [delaySeconds=0] Optional delay (0–60s) before the push
+   *   is sent, so the user can background/close the app and verify the
+   *   system banner appears. When delayed, the method returns immediately
+   *   with `{ scheduled: true }` and the send happens server-side.
+   * @returns {{ sent: Number }|{ scheduled: true, delaySeconds: Number, devices: Number }}
    */
-  "notifications.sendTest": async function () {
+  "notifications.sendTest": async function (delaySeconds = 0) {
+    check(delaySeconds, Match.Integer);
+    if (delaySeconds < 0 || delaySeconds > 60) {
+      throw new Meteor.Error(
+        "invalid-delay",
+        "Delay must be between 0 and 60 seconds.",
+      );
+    }
+
     const userId = this.userId;
     if (!userId) {
       throw new Meteor.Error(
@@ -2190,22 +2202,39 @@ Meteor.methods({
       isSync: "false",
     };
 
-    const results = await Promise.allSettled(
-      validTokens.map((token) =>
-        sendNotification(
-          token,
-          "Test Notification",
-          "Your push notifications are working correctly.",
-          notificationData,
+    const sendToAllDevices = async () => {
+      const results = await Promise.allSettled(
+        validTokens.map((token) =>
+          sendNotification(
+            token,
+            "Test Notification",
+            "Your push notifications are working correctly.",
+            notificationData,
+          ),
         ),
-      ),
-    );
+      );
 
-    // sendNotification resolves with a message id on success and null when
-    // Firebase is not initialised, so only count deliveries with a real id.
-    const sent = results.filter(
-      (r) => r.status === "fulfilled" && r.value,
-    ).length;
+      // sendNotification resolves with a message id on success and null when
+      // Firebase is not initialised, so only count deliveries with a real id.
+      return results.filter((r) => r.status === "fulfilled" && r.value).length;
+    };
+
+    // Delayed send: schedule server-side and return immediately so the user
+    // can background or close the app to verify the system banner appears.
+    if (delaySeconds > 0) {
+      Meteor.setTimeout(() => {
+        sendToAllDevices().catch((error) => {
+          console.error("Delayed test notification failed:", error);
+        });
+      }, delaySeconds * 1000);
+      return {
+        scheduled: true,
+        delaySeconds,
+        devices: validTokens.length,
+      };
+    }
+
+    const sent = await sendToAllDevices();
     if (sent === 0) {
       throw new Meteor.Error(
         "notification-failed",


### PR DESCRIPTION
Closes #419

## Summary
Adds an in-app **Test** button so a signed-in user can send a push notification to their **own approved device(s)** and verify delivery end-to-end — covering both **foreground** (in-app) and **background** (system banner) behavior — without triggering a real authentication flow.

## How it works
### Sending
- New `notifications.sendTest` Meteor method. The target is derived from `this.userId` only (never a client-supplied id), so users can only test their own devices.
- Optional **delayed send** (`delaySeconds`, validated integer 0–60): the push is scheduled **server-side** via `Meteor.setTimeout` and the method returns immediately, so the user can close/background the app and watch for the system banner. The header button offers **Send now / in 5s / in 10s / in 30s**.
- The payload is intentionally **non-actionable** — no `appId`, `notificationId`, or `actions` — so the client never treats it as an approval request.

### Foreground behavior (important)
- iOS `forceShow` is deliberately **left off**. With `forceShow: true` the push plugin only shows the OS banner for foreground pushes and defers the JS `notification` event until tap (`PushPlugin.m` → `willPresentNotification`), which **breaks the auto-opening approve/reject actions modal**. A code comment now documents this so it isn't re-enabled accidentally.
- Instead, a test push arriving while the app is open is surfaced as an **in-app toast** explaining that the OS only shows a banner when the app is backgrounded, and suggesting a delayed send to test that.

### iOS / watchOS actions
- `server/firebase.js` now attaches the `APPROVAL` APNs category **only when the payload actually carries approval `actions`**, so the test push (and any other informational push) never renders Approve/Reject buttons on iOS or a paired Apple Watch.

### UI
- `SuccessToaster` gains an error variant, a message-driven auto-close timer, respects the iOS safe-area inset, and caps its width so it no longer overlaps the header.

## Files
| Change | File |
|---|---|
| New — header Test button with send-now/delayed menu + foreground-receipt toast | `client/mobile/src/ui/components/TestNotificationButton.jsx` |
| Header entry point | `client/mobile/src/ui/components/DashboardHeader.jsx` |
| Foreground test-push detection; forceShow kept off + documented | `client/mobile/push-notifications.js` |
| `notifications.sendTest` method with optional delay | `server/main.js` |
| APNs approval category only for actionable pushes | `server/firebase.js` |
| Toast variant, safe-area positioning, width cap | `client/mobile/src/ui/Toasters/SuccessToaster.jsx` |

## Security / least privilege
- Server derives the recipient from the authenticated session (`this.userId`); no client-supplied identifiers.
- Delay input validated server-side (`Match.Integer`, 0–60).
- Test payload is non-actionable by construction; approval semantics unreachable from this path.

## Testing
- **Foreground:** app open → Test → Send now → in-app toast confirms receipt and explains why there is no OS banner. Approve/reject modal still auto-opens for real approval pushes (no regression).
- **Background:** Test → Send in 30s → background/close the app → system banner appears; on iOS/watchOS it shows **no** Approve/Reject actions.
- **No devices:** user without an approved device gets a clear error toast.