### PR TITLE
Add self-service device management ("My Devices") with security hardening

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -22,6 +22,7 @@ react-meteor-data       # React higher-order component for reactively tracking M
 http
 accounts-password@3.2.2
 accounts-base@3.2.0
+ddp-rate-limiter@1.2.2    # Brute-force protection for auth/device management methods
 check@1.5.0
 session@1.2.2
 sha@1.0.10

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -242,6 +242,29 @@ const setupNotificationHandler = (push) => {
         return;
       }
 
+      // Informational device-trust pushes (primary changed, device added,
+      // device-removed notice). When the app is OPEN, iOS shows no banner for
+      // foreground pushes (forceShow is deliberately off), so surface an
+      // in-app toast; backgrounded devices already got the OS banner.
+      if (
+        [
+          "primary_changed",
+          "device_added_info",
+          "device_removed_info",
+        ].includes(additionalData.notificationType)
+      ) {
+        if (additionalData.foreground) {
+          Session.set("deviceTrustNotice", {
+            message:
+              notification.message ||
+              additionalData.body ||
+              "Your device settings changed.",
+            timestamp: new Date().getTime(),
+          });
+        }
+        return;
+      }
+
       // Test notification received while the app is in the foreground.
       // Foreground pushes are delivered straight to this handler (no OS
       // banner, since forceShow is off), so surface an in-app toast that

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -221,6 +221,27 @@ const setupNotificationHandler = (push) => {
         }, 2000);
       }
 
+      // This device was revoked from the account (via My Devices on another
+      // device or by an admin). Wipe local credentials and sign out — the
+      // server has already deleted this device's record and invalidated its
+      // sessions, so this is a cleanup courtesy for the user.
+      if (additionalData.notificationType === "device_revoked") {
+        [
+          "biometricsEnabled",
+          "biometricUserId",
+          "lastLoggedInEmail",
+          "pendingNotification",
+        ].forEach((key) => {
+          try {
+            localStorage.removeItem(key);
+          } catch {}
+        });
+        Meteor.logout(() => {
+          window.location.replace("/");
+        });
+        return;
+      }
+
       // Test notification received while the app is in the foreground.
       // Foreground pushes are delivered straight to this handler (no OS
       // banner, since forceShow is off), so surface an in-app toast that

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { useTracker } from "meteor/react-meteor-data";
 import {
   ArrowLeft,
+  Apple,
   Check,
   Fingerprint as FingerprintIcon,
   Pencil,
@@ -12,6 +13,7 @@ import {
   Smartphone,
   Star,
   Trash2,
+  Watch,
   X,
 } from "lucide-react";
 import {
@@ -34,13 +36,45 @@ const STATUS_BADGES = {
   rejected: { variant: "secondary", label: "Rejected" },
 };
 
+const isUnknown = (value) =>
+  ["", "unknown"].includes((value || "").toString().trim().toLowerCase());
+
+// Normalize a platform string to a known kind so we can pick an icon and
+// describe watch support consistently.
+const platformKind = (platform) => {
+  const p = (platform || "").toLowerCase();
+  if (p.includes("ios") || p.includes("iphone") || p.includes("ipad")) {
+    return "ios";
+  }
+  if (p.includes("android")) return "android";
+  return "unknown";
+};
+
+const PLATFORM_META = {
+  ios: {
+    Icon: Apple,
+    label: "iOS",
+    tint: "text-foreground bg-muted",
+    watch: "Apple Watch",
+  },
+  android: {
+    Icon: Smartphone,
+    label: "Android",
+    tint: "text-emerald-600 bg-emerald-500/10",
+    watch: "Wear OS watch",
+  },
+  unknown: {
+    Icon: Smartphone,
+    label: "Unknown platform",
+    tint: "text-primary bg-primary/10",
+    watch: null,
+  },
+};
+
 const formatLastUsed = (device) => {
   const when = device.lastUsed || device.lastUpdated;
   return when ? new Date(when).toLocaleString() : "Never";
 };
-
-const deviceLabel = (device) =>
-  device.customName || device.deviceModel || "Unknown device";
 
 // Prompt the OS biometric dialog and resolve with the device-bound secret.
 // The secret is only released by the OS after a successful biometric check,
@@ -63,28 +97,39 @@ const getBiometricProof = () =>
   });
 
 /**
- * Step-up confirmation modal for destructive device actions. The user must
- * verify with biometrics (preferred) or their account PIN before the action
- * is sent to the server.
+ * Step-up confirmation modal for destructive device actions.
+ *
+ * Biometrics are attempted FIRST (auto-triggered on open when available); the
+ * PIN entry is only shown as a fallback when biometrics are unavailable, fail,
+ * or the user chooses "Use PIN instead".
  */
 const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
+  const biometricsAvailable = !!window.Fingerprint;
+  const [mode, setMode] = useState(biometricsAvailable ? "biometric" : "pin");
+  const [verifying, setVerifying] = useState(false);
   const [pin, setPin] = useState("");
-  const [usePin, setUsePin] = useState(!Session.get("Biometrics"));
   const [localError, setLocalError] = useState("");
 
-  if (!action) return null;
-
-  const handleBiometricConfirm = async () => {
+  const runBiometric = async () => {
     setLocalError("");
+    setVerifying(true);
     try {
       const proof = await getBiometricProof();
       onConfirm(proof);
     } catch (err) {
       // Fall back to PIN entry when biometrics fail or are cancelled.
-      setLocalError(err.message);
-      setUsePin(true);
+      setLocalError(`${err.message} Enter your PIN to continue.`);
+      setMode("pin");
+    } finally {
+      setVerifying(false);
     }
   };
+
+  // Auto-trigger the biometric prompt as soon as the modal opens.
+  useEffect(() => {
+    if (biometricsAvailable) runBiometric();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handlePinConfirm = () => {
     setLocalError("");
@@ -96,9 +141,10 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
   };
 
   const message = error || localError;
+  const disabled = busy || verifying;
 
   return (
-    <Modal open onOpenChange={(open) => !open && !busy && onClose()}>
+    <Modal open onOpenChange={(open) => !open && !disabled && onClose()}>
       <ModalBody>
         <div className="space-y-4 p-1">
           <h3 className="text-base font-semibold text-foreground">
@@ -118,7 +164,29 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
             </Alert>
           )}
 
-          {usePin ? (
+          {mode === "biometric" ? (
+            <div className="space-y-3">
+              <Button
+                className="w-full"
+                onClick={runBiometric}
+                disabled={disabled}
+              >
+                <FingerprintIcon className="h-4 w-4 mr-2" />
+                {verifying ? "Verifying…" : "Verify with biometrics"}
+              </Button>
+              <Button
+                variant="ghost"
+                className="w-full"
+                onClick={() => {
+                  setLocalError("");
+                  setMode("pin");
+                }}
+                disabled={disabled}
+              >
+                Use PIN instead
+              </Button>
+            </div>
+          ) : (
             <div className="space-y-2">
               <Input
                 type="password"
@@ -128,31 +196,37 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
                 value={pin}
                 onChange={(e) => setPin(e.target.value)}
                 disabled={busy}
+                autoFocus
               />
               <Button
                 className="w-full"
                 onClick={handlePinConfirm}
                 disabled={busy}
               >
-                {busy ? "Verifying..." : action.confirmLabel}
+                {busy ? "Verifying…" : action.confirmLabel}
               </Button>
+              {biometricsAvailable && (
+                <Button
+                  variant="ghost"
+                  className="w-full"
+                  onClick={() => {
+                    setLocalError("");
+                    setMode("biometric");
+                  }}
+                  disabled={busy}
+                >
+                  <FingerprintIcon className="h-4 w-4 mr-2" />
+                  Use biometrics instead
+                </Button>
+              )}
             </div>
-          ) : (
-            <Button
-              className="w-full"
-              onClick={handleBiometricConfirm}
-              disabled={busy}
-            >
-              <FingerprintIcon className="h-4 w-4 mr-2" />
-              {busy ? "Verifying..." : "Verify with biometrics"}
-            </Button>
           )}
 
           <Button
             variant="ghost"
             className="w-full"
             onClick={onClose}
-            disabled={busy}
+            disabled={disabled}
           >
             Cancel
           </Button>
@@ -164,7 +238,8 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
 
 const DeviceManagementPage = () => {
   const navigate = useNavigate();
-  const currentUuid = Session.get("capturedDeviceInfo")?.uuid || null;
+  const capturedInfo = Session.get("capturedDeviceInfo") || null;
+  const currentUuid = capturedInfo?.uuid || null;
 
   const [renamingUuid, setRenamingUuid] = useState(null);
   const [renameValue, setRenameValue] = useState("");
@@ -181,6 +256,37 @@ const DeviceManagementPage = () => {
     const userDoc = DeviceDetails.findOne({ userId });
     return { devices: userDoc?.devices || [], isLoading: !handle.ready() };
   }, []);
+
+  const approvedCount = devices.filter(
+    (d) => d.deviceRegistrationStatus === "approved",
+  ).length;
+
+  // Resolve display info for a device. For the CURRENT device we fall back to
+  // the live captured OS info when the stored record is missing/"Unknown"
+  // (older registrations stored placeholders).
+  const resolve = (device) => {
+    const isCurrent = device.deviceUUID === currentUuid;
+
+    let platform = device.devicePlatform;
+    if (isUnknown(platform) && isCurrent) platform = capturedInfo?.platform;
+
+    let model = device.deviceModel;
+    if (isUnknown(model) && isCurrent) model = capturedInfo?.model;
+
+    const kind = platformKind(platform);
+    const meta = PLATFORM_META[kind];
+
+    const name =
+      device.customName ||
+      (!isUnknown(model) ? model : null) ||
+      (kind !== "unknown"
+        ? `${meta.label} device`
+        : isCurrent
+          ? "This device"
+          : "Unknown device");
+
+    return { isCurrent, kind, meta, name };
+  };
 
   // Current device first, then primary, then most recently used.
   const sortedDevices = [...devices].sort((a, b) => {
@@ -209,10 +315,10 @@ const DeviceManagementPage = () => {
     Meteor.logout(() => window.location.replace("/"));
   };
 
-  const startRename = (device) => {
+  const startRename = (device, name) => {
     setPageError("");
     setRenamingUuid(device.deviceUUID);
-    setRenameValue(device.customName || device.deviceModel || "");
+    setRenameValue(device.customName || name);
   };
 
   const saveRename = async (device) => {
@@ -239,14 +345,14 @@ const DeviceManagementPage = () => {
     }
   };
 
-  const requestRevoke = (device) => {
+  const requestRevoke = (device, name) => {
     const isCurrent = device.deviceUUID === currentUuid;
     const isLast = devices.length === 1;
     setActionError("");
     setPendingAction({
       type: "revoke",
       device,
-      title: `Remove "${deviceLabel(device)}"?`,
+      title: `Remove "${name}"?`,
       description:
         "This device will no longer receive authentication requests and will be signed out.",
       warning: isLast
@@ -258,14 +364,12 @@ const DeviceManagementPage = () => {
     });
   };
 
-  const requestPendingResponse = (device, approve) => {
+  const requestPendingResponse = (device, name, approve) => {
     setActionError("");
     setPendingAction({
       type: approve ? "approve" : "reject",
       device,
-      title: approve
-        ? `Approve "${deviceLabel(device)}"?`
-        : `Reject "${deviceLabel(device)}"?`,
+      title: approve ? `Approve "${name}"?` : `Reject "${name}"?`,
       description: approve
         ? "This device will be able to receive and respond to authentication requests for your account."
         : "This device's registration request will be rejected and removed.",
@@ -359,18 +463,30 @@ const DeviceManagementPage = () => {
           </Card>
         ) : (
           sortedDevices.map((device) => {
-            const isCurrent = device.deviceUUID === currentUuid;
+            const { isCurrent, meta, name } = resolve(device);
+            const { Icon } = meta;
+            const isApproved = device.deviceRegistrationStatus === "approved";
+            const isPending = device.deviceRegistrationStatus === "pending";
             const status =
               STATUS_BADGES[device.deviceRegistrationStatus] ||
               STATUS_BADGES.rejected;
             const isRenaming = renamingUuid === device.deviceUUID;
 
+            // A lone approved device is effectively primary even if the stored
+            // flag was never set.
+            const isEffectivePrimary =
+              isApproved && (device.isPrimary || approvedCount <= 1);
+            const canMakePrimary =
+              isApproved && !isEffectivePrimary && approvedCount > 1;
+
             return (
               <Card key={device.deviceUUID}>
                 <CardContent className="space-y-3 p-4">
                   <div className="flex items-start gap-3">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10">
-                      <Smartphone className="h-5 w-5 text-primary" />
+                    <div
+                      className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl ${meta.tint}`}
+                    >
+                      <Icon className="h-5 w-5" />
                     </div>
                     <div className="flex-1 min-w-0">
                       {isRenaming ? (
@@ -401,9 +517,9 @@ const DeviceManagementPage = () => {
                       ) : (
                         <div className="flex items-center gap-1.5 min-w-0">
                           <h3 className="text-sm font-semibold text-foreground truncate">
-                            {deviceLabel(device)}
+                            {name}
                           </h3>
-                          {device.isPrimary && (
+                          {isEffectivePrimary && (
                             <Star
                               className="h-3.5 w-3.5 shrink-0 text-amber-500 fill-amber-500"
                               aria-label="Primary device"
@@ -413,21 +529,24 @@ const DeviceManagementPage = () => {
                             variant="ghost"
                             aria-label="Rename device"
                             className="p-1.5 h-auto"
-                            onClick={() => startRename(device)}
+                            onClick={() => startRename(device, name)}
                           >
                             <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
                           </Button>
                         </div>
                       )}
                       <p className="text-xs text-muted-foreground truncate">
-                        {device.devicePlatform || "Unknown platform"}
-                        {device.deviceModel && device.customName
-                          ? ` · ${device.deviceModel}`
-                          : ""}
+                        {meta.label}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         Last used: {formatLastUsed(device)}
                       </p>
+                      {isApproved && meta.watch && (
+                        <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                          <Watch className="h-3.5 w-3.5" />
+                          {meta.watch} notifications supported
+                        </p>
+                      )}
                     </div>
                     <div className="flex flex-col items-end gap-1 shrink-0">
                       <Badge variant={status.variant} size="sm">
@@ -441,13 +560,15 @@ const DeviceManagementPage = () => {
                     </div>
                   </div>
 
-                  <div className="flex flex-wrap gap-2">
-                    {device.deviceRegistrationStatus === "pending" ? (
+                  <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
+                    {isPending ? (
                       <>
                         <Button
                           size="sm"
                           disabled={!currentUuid || isCurrent}
-                          onClick={() => requestPendingResponse(device, true)}
+                          onClick={() =>
+                            requestPendingResponse(device, name, true)
+                          }
                         >
                           <ShieldCheck className="h-4 w-4 mr-1.5" />
                           Approve
@@ -457,14 +578,15 @@ const DeviceManagementPage = () => {
                           variant="ghost"
                           className="text-destructive"
                           disabled={!currentUuid || isCurrent}
-                          onClick={() => requestPendingResponse(device, false)}
+                          onClick={() =>
+                            requestPendingResponse(device, name, false)
+                          }
                         >
                           Reject
                         </Button>
                       </>
                     ) : (
-                      !device.isPrimary &&
-                      device.deviceRegistrationStatus === "approved" && (
+                      canMakePrimary && (
                         <Button
                           size="sm"
                           variant="ghost"
@@ -481,7 +603,7 @@ const DeviceManagementPage = () => {
                       variant="ghost"
                       className="text-destructive ml-auto"
                       disabled={!currentUuid}
-                      onClick={() => requestRevoke(device)}
+                      onClick={() => requestRevoke(device, name)}
                     >
                       <Trash2 className="h-4 w-4 mr-1.5" />
                       Remove

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -172,7 +172,7 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
           )}
 
           {message && (
-            <Alert variant="error">
+            <Alert variant="danger">
               <AlertDescription>{message}</AlertDescription>
             </Alert>
           )}
@@ -258,6 +258,7 @@ const DeviceManagementPage = () => {
   const [renameValue, setRenameValue] = useState("");
   const [pendingAction, setPendingAction] = useState(null);
   const [busy, setBusy] = useState(false);
+  const [transferringUuid, setTransferringUuid] = useState(null);
   const [actionError, setActionError] = useState("");
   const [pageError, setPageError] = useState("");
 
@@ -348,13 +349,20 @@ const DeviceManagementPage = () => {
   };
 
   const setPrimary = async (device) => {
+    if (!currentUuid) return;
     setPageError("");
+    setTransferringUuid(device.deviceUUID);
     try {
+      // May block for up to ~25s while the current primary device is asked
+      // to approve the transfer via an actionable push.
       await Meteor.callAsync("devices.setPrimary", {
         deviceUUID: device.deviceUUID,
+        actorDeviceUUID: currentUuid,
       });
     } catch (err) {
       setPageError(err.reason || err.message || "Failed to update device.");
+    } finally {
+      setTransferringUuid(null);
     }
   };
 
@@ -450,8 +458,17 @@ const DeviceManagementPage = () => {
         </p>
 
         {pageError && (
-          <Alert variant="error">
+          <Alert variant="danger">
             <AlertDescription>{pageError}</AlertDescription>
+          </Alert>
+        )}
+
+        {transferringUuid && (
+          <Alert variant="info">
+            <AlertDescription>
+              Approval request sent to your primary device. Approve it there to
+              complete the change.
+            </AlertDescription>
           </Alert>
         )}
 
@@ -607,24 +624,32 @@ const DeviceManagementPage = () => {
                         <Button
                           size="sm"
                           variant="ghost"
-                          disabled={!currentUuid}
+                          disabled={!currentUuid || !!transferringUuid}
                           onClick={() => setPrimary(device)}
                         >
                           <Star className="h-4 w-4 mr-1.5" />
-                          Make primary
+                          {transferringUuid === device.deviceUUID
+                            ? "Waiting for approval…"
+                            : "Make primary"}
                         </Button>
                       )
                     )}
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="text-destructive ml-auto"
-                      disabled={!currentUuid}
-                      onClick={() => requestRevoke(device, name)}
-                    >
-                      <Trash2 className="h-4 w-4 mr-1.5" />
-                      Remove
-                    </Button>
+                    {/* The primary (or only approved) device can never be
+                        removed — the account always keeps one trusted device.
+                        Transfer the primary role first (approved on the
+                        current primary) to remove this device. */}
+                    {!isEffectivePrimary && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-destructive ml-auto"
+                        disabled={!currentUuid}
+                        onClick={() => requestRevoke(device, name)}
+                      >
+                        <Trash2 className="h-4 w-4 mr-1.5" />
+                        Remove
+                      </Button>
+                    )}
                   </div>
                 </CardContent>
               </Card>

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -28,6 +28,7 @@ import {
   Spinner,
 } from "@mieweb/ui";
 import { DeviceDetails } from "../../../../utils/api/deviceDetails";
+import SuccessToaster from "./Toasters/SuccessToaster";
 
 const STATUS_BADGES = {
   approved: { variant: "success", label: "Approved" },
@@ -103,7 +104,13 @@ const getBiometricProof = () =>
         description: "Confirm it's you to manage your devices",
         disableBackup: true,
       },
-      (secret) => resolve({ biometricSecret: secret }),
+      (secret) =>
+        // Some devices "succeed" with an empty secret when no biometric
+        // credential is stored — treat that as a failure so the caller falls
+        // back to PIN instead of sending an invalid proof to the server.
+        secret
+          ? resolve({ biometricSecret: secret })
+          : reject(new Error("No biometric credential found on this device.")),
       (err) =>
         reject(new Error(err?.message || "Biometric verification cancelled.")),
     );
@@ -112,13 +119,18 @@ const getBiometricProof = () =>
 /**
  * Step-up confirmation modal for destructive device actions.
  *
- * Biometrics are attempted FIRST (auto-triggered on open when available); the
- * PIN entry is only shown as a fallback when biometrics are unavailable, fail,
- * or the user chooses "Use PIN instead".
+ * Preference order: biometrics FIRST (auto-triggered on open), PIN as the
+ * fallback — when biometrics fail, are cancelled, or the user chooses
+ * "Use PIN instead".
+ *
+ * NOTE: deliberately NO Fingerprint.isAvailable pre-check — it misreports
+ * Face ID on iOS simulators even when enrolled, while loadBiometricSecret
+ * works (the login flow relies on the same direct call). Failures simply
+ * drop to PIN.
  */
 const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
-  const biometricsAvailable = !!window.Fingerprint;
-  const [mode, setMode] = useState(biometricsAvailable ? "biometric" : "pin");
+  const bioSupported = !!window.Fingerprint;
+  const [mode, setMode] = useState(bioSupported ? "biometric" : "pin");
   const [verifying, setVerifying] = useState(false);
   const [pin, setPin] = useState("");
   const [localError, setLocalError] = useState("");
@@ -138,9 +150,10 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
     }
   };
 
-  // Auto-trigger the biometric prompt as soon as the modal opens.
+  // Auto-trigger the biometric prompt as soon as the modal opens (same
+  // direct-call pattern as the biometric login flow).
   useEffect(() => {
-    if (biometricsAvailable) runBiometric();
+    if (bioSupported) runBiometric();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -218,7 +231,7 @@ const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
               >
                 {busy ? "Verifying…" : action.confirmLabel}
               </Button>
-              {biometricsAvailable && (
+              {bioSupported && (
                 <Button
                   variant="ghost"
                   className="w-full"
@@ -258,7 +271,6 @@ const DeviceManagementPage = () => {
   const [renameValue, setRenameValue] = useState("");
   const [pendingAction, setPendingAction] = useState(null);
   const [busy, setBusy] = useState(false);
-  const [transferringUuid, setTransferringUuid] = useState(null);
   const [actionError, setActionError] = useState("");
   const [pageError, setPageError] = useState("");
 
@@ -270,6 +282,11 @@ const DeviceManagementPage = () => {
     const userDoc = DeviceDetails.findOne({ userId });
     return { devices: userDoc?.devices || [], isLoading: !handle.ready() };
   }, []);
+
+  // Device-trust push received while the app is open (set by
+  // push-notifications.js) — shown as a toast since iOS foreground pushes
+  // have no OS banner.
+  const trustNotice = useTracker(() => Session.get("deviceTrustNotice"), []);
 
   const approvedCount = devices.filter(
     (d) => d.deviceRegistrationStatus === "approved",
@@ -348,22 +365,25 @@ const DeviceManagementPage = () => {
     }
   };
 
-  const setPrimary = async (device) => {
-    if (!currentUuid) return;
-    setPageError("");
-    setTransferringUuid(device.deviceUUID);
-    try {
-      // May block for up to ~25s while the current primary device is asked
-      // to approve the transfer via an actionable push.
-      await Meteor.callAsync("devices.setPrimary", {
-        deviceUUID: device.deviceUUID,
-        actorDeviceUUID: currentUuid,
-      });
-    } catch (err) {
-      setPageError(err.reason || err.message || "Failed to update device.");
-    } finally {
-      setTransferringUuid(null);
-    }
+  const requestSetPrimary = (device, name) => {
+    const currentDevice = devices.find((d) => d.deviceUUID === currentUuid);
+    const currentIsPrimary =
+      currentDevice &&
+      currentDevice.deviceRegistrationStatus === "approved" &&
+      (currentDevice.isPrimary || approvedCount <= 1);
+
+    setActionError("");
+    setPendingAction({
+      type: "setPrimary",
+      device,
+      title: `Make "${name}" your primary device?`,
+      description:
+        "The primary device receives new-device approval requests for your account.",
+      warning: currentIsPrimary
+        ? "This device will hand over its primary role. Verify it's you to continue."
+        : "Your current primary device will be asked to approve this change — keep it nearby.",
+      confirmLabel: "Make primary",
+    });
   };
 
   const requestRevoke = (device, name) => {
@@ -419,6 +439,21 @@ const DeviceManagementPage = () => {
           wipeLocalAndLogout();
           return;
         }
+      } else if (pendingAction.type === "setPrimary") {
+        // May block for up to ~25s while the current primary device is asked
+        // to approve the transfer via an actionable push.
+        await Meteor.callAsync("devices.setPrimary", {
+          deviceUUID: pendingAction.device.deviceUUID,
+          actorDeviceUUID: currentUuid,
+          reAuth,
+        });
+        // The server pushes the confirmation after a short delay so it can
+        // land as a visible OS banner — tell the user how to see it.
+        Session.set("deviceTrustNotice", {
+          message:
+            "Primary device updated. A confirmation notification arrives in ~10s — close or background the app to see it.",
+          timestamp: new Date().getTime(),
+        });
       } else {
         await Meteor.callAsync("devices.approvePending", {
           deviceUUID: pendingAction.device.deviceUUID,
@@ -437,6 +472,10 @@ const DeviceManagementPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SuccessToaster
+        message={trustNotice?.message || ""}
+        onClose={() => Session.set("deviceTrustNotice", null)}
+      />
       <header className="relative z-50 bg-card shadow-sm sm:sticky sm:top-0">
         <div className="px-4 py-2.5 flex items-center gap-2">
           <Button
@@ -460,15 +499,6 @@ const DeviceManagementPage = () => {
         {pageError && (
           <Alert variant="danger">
             <AlertDescription>{pageError}</AlertDescription>
-          </Alert>
-        )}
-
-        {transferringUuid && (
-          <Alert variant="info">
-            <AlertDescription>
-              Approval request sent to your primary device. Approve it there to
-              complete the change.
-            </AlertDescription>
           </Alert>
         )}
 
@@ -624,13 +654,11 @@ const DeviceManagementPage = () => {
                         <Button
                           size="sm"
                           variant="ghost"
-                          disabled={!currentUuid || !!transferringUuid}
-                          onClick={() => setPrimary(device)}
+                          disabled={!currentUuid}
+                          onClick={() => requestSetPrimary(device, name)}
                         >
                           <Star className="h-4 w-4 mr-1.5" />
-                          {transferringUuid === device.deviceUUID
-                            ? "Waiting for approval…"
-                            : "Make primary"}
+                          Make primary
                         </Button>
                       )
                     )}

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -5,7 +5,6 @@ import { Session } from "meteor/session";
 import { useTracker } from "meteor/react-meteor-data";
 import {
   ArrowLeft,
-  Apple,
   Check,
   Fingerprint as FingerprintIcon,
   Pencil,
@@ -52,9 +51,9 @@ const platformKind = (platform) => {
 
 const PLATFORM_META = {
   ios: {
-    Icon: Apple,
+    Icon: Smartphone,
     label: "iOS",
-    tint: "text-foreground bg-muted",
+    tint: "text-blue-600 bg-blue-500/10",
     watch: "Apple Watch",
   },
   android: {

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -38,6 +38,20 @@ const STATUS_BADGES = {
 const isUnknown = (value) =>
   ["", "unknown"].includes((value || "").toString().trim().toLowerCase());
 
+// Official brand glyphs (lucide has no brand icons). Paths from Simple Icons
+// (CC0), rendered in currentColor so they follow the tile tint.
+const AppleLogo = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701" />
+  </svg>
+);
+
+const AndroidLogo = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M17.523 15.3414c-.5511 0-.9993-.4486-.9993-.9997s.4482-.9993.9993-.9993c.5511 0 .9993.4483.9993.9993.0001.5511-.4482.9997-.9993.9997m-11.046 0c-.5511 0-.9993-.4486-.9993-.9997s.4482-.9993.9993-.9993c.5511 0 .9993.4483.9993.9993 0 .5511-.4482.9997-.9993.9997m11.4045-6.02l1.9973-3.4592a.416.416 0 00-.1521-.5676.416.416 0 00-.5676.1521l-2.0223 3.503C15.5902 8.2439 13.8533 7.8508 12 7.8508s-3.5902.3931-5.1367 1.0989L4.841 5.4467a.4161.4161 0 00-.5677-.1521.4157.4157 0 00-.1521.5676l1.9973 3.4592C2.6889 11.1867.3432 14.6589 0 18.761h24c-.3435-4.1021-2.6892-7.5743-6.1185-9.4396" />
+  </svg>
+);
+
 // Normalize a platform string to a known kind so we can pick an icon and
 // describe watch support consistently.
 const platformKind = (platform) => {
@@ -51,15 +65,15 @@ const platformKind = (platform) => {
 
 const PLATFORM_META = {
   ios: {
-    Icon: Smartphone,
+    Icon: AppleLogo,
     label: "iOS",
-    tint: "text-blue-600 bg-blue-500/10",
+    tint: "text-foreground bg-muted",
     watch: "Apple Watch",
   },
   android: {
-    Icon: Smartphone,
+    Icon: AndroidLogo,
     label: "Android",
-    tint: "text-emerald-600 bg-emerald-500/10",
+    tint: "text-emerald-500 bg-emerald-500/10",
     watch: "Wear OS watch",
   },
   unknown: {
@@ -518,12 +532,6 @@ const DeviceManagementPage = () => {
                           <h3 className="text-sm font-semibold text-foreground truncate">
                             {name}
                           </h3>
-                          {isEffectivePrimary && (
-                            <Star
-                              className="h-3.5 w-3.5 shrink-0 text-amber-500 fill-amber-500"
-                              aria-label="Primary device"
-                            />
-                          )}
                           <Button
                             variant="ghost"
                             aria-label="Rename device"
@@ -551,6 +559,16 @@ const DeviceManagementPage = () => {
                       <Badge variant={status.variant} size="sm">
                         {status.label}
                       </Badge>
+                      {isEffectivePrimary && (
+                        <Badge
+                          variant="secondary"
+                          size="sm"
+                          className="bg-amber-500/15 text-amber-600"
+                        >
+                          <Star className="h-3 w-3 mr-1 fill-current" />
+                          Primary
+                        </Badge>
+                      )}
                       {isCurrent && (
                         <Badge variant="secondary" size="sm">
                           This device

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -1,0 +1,513 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Meteor } from "meteor/meteor";
+import { Session } from "meteor/session";
+import { useTracker } from "meteor/react-meteor-data";
+import {
+  ArrowLeft,
+  Check,
+  Fingerprint as FingerprintIcon,
+  Pencil,
+  ShieldCheck,
+  Smartphone,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  Alert,
+  AlertDescription,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Modal,
+  ModalBody,
+  Spinner,
+} from "@mieweb/ui";
+import { DeviceDetails } from "../../../../utils/api/deviceDetails";
+
+const STATUS_BADGES = {
+  approved: { variant: "success", label: "Approved" },
+  pending: { variant: "warning", label: "Pending" },
+  rejected: { variant: "secondary", label: "Rejected" },
+};
+
+const formatLastUsed = (device) => {
+  const when = device.lastUsed || device.lastUpdated;
+  return when ? new Date(when).toLocaleString() : "Never";
+};
+
+const deviceLabel = (device) =>
+  device.customName || device.deviceModel || "Unknown device";
+
+// Prompt the OS biometric dialog and resolve with the device-bound secret.
+// The secret is only released by the OS after a successful biometric check,
+// which is what makes it usable as step-up re-authentication proof.
+const getBiometricProof = () =>
+  new Promise((resolve, reject) => {
+    if (!window.Fingerprint) {
+      reject(new Error("Biometric authentication is unavailable."));
+      return;
+    }
+    window.Fingerprint.loadBiometricSecret(
+      {
+        description: "Confirm it's you to manage your devices",
+        disableBackup: true,
+      },
+      (secret) => resolve({ biometricSecret: secret }),
+      (err) =>
+        reject(new Error(err?.message || "Biometric verification cancelled.")),
+    );
+  });
+
+/**
+ * Step-up confirmation modal for destructive device actions. The user must
+ * verify with biometrics (preferred) or their account PIN before the action
+ * is sent to the server.
+ */
+const ConfirmActionModal = ({ action, busy, error, onClose, onConfirm }) => {
+  const [pin, setPin] = useState("");
+  const [usePin, setUsePin] = useState(!Session.get("Biometrics"));
+  const [localError, setLocalError] = useState("");
+
+  if (!action) return null;
+
+  const handleBiometricConfirm = async () => {
+    setLocalError("");
+    try {
+      const proof = await getBiometricProof();
+      onConfirm(proof);
+    } catch (err) {
+      // Fall back to PIN entry when biometrics fail or are cancelled.
+      setLocalError(err.message);
+      setUsePin(true);
+    }
+  };
+
+  const handlePinConfirm = () => {
+    setLocalError("");
+    if (!pin.trim()) {
+      setLocalError("Enter your PIN to continue.");
+      return;
+    }
+    onConfirm({ pin: pin.trim() });
+  };
+
+  const message = error || localError;
+
+  return (
+    <Modal open onOpenChange={(open) => !open && !busy && onClose()}>
+      <ModalBody>
+        <div className="space-y-4 p-1">
+          <h3 className="text-base font-semibold text-foreground">
+            {action.title}
+          </h3>
+          <p className="text-sm text-muted-foreground">{action.description}</p>
+
+          {action.warning && (
+            <Alert variant="warning">
+              <AlertDescription>{action.warning}</AlertDescription>
+            </Alert>
+          )}
+
+          {message && (
+            <Alert variant="error">
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          )}
+
+          {usePin ? (
+            <div className="space-y-2">
+              <Input
+                type="password"
+                inputMode="numeric"
+                autoComplete="current-password"
+                placeholder="Enter your PIN"
+                value={pin}
+                onChange={(e) => setPin(e.target.value)}
+                disabled={busy}
+              />
+              <Button
+                className="w-full"
+                onClick={handlePinConfirm}
+                disabled={busy}
+              >
+                {busy ? "Verifying..." : action.confirmLabel}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={handleBiometricConfirm}
+              disabled={busy}
+            >
+              <FingerprintIcon className="h-4 w-4 mr-2" />
+              {busy ? "Verifying..." : "Verify with biometrics"}
+            </Button>
+          )}
+
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+};
+
+const DeviceManagementPage = () => {
+  const navigate = useNavigate();
+  const currentUuid = Session.get("capturedDeviceInfo")?.uuid || null;
+
+  const [renamingUuid, setRenamingUuid] = useState(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [pendingAction, setPendingAction] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState("");
+  const [pageError, setPageError] = useState("");
+
+  const { devices, isLoading } = useTracker(() => {
+    const userId = Meteor.userId();
+    if (!userId) return { devices: [], isLoading: false };
+
+    const handle = Meteor.subscribe("deviceDetails.byUser", userId);
+    const userDoc = DeviceDetails.findOne({ userId });
+    return { devices: userDoc?.devices || [], isLoading: !handle.ready() };
+  }, []);
+
+  // Current device first, then primary, then most recently used.
+  const sortedDevices = [...devices].sort((a, b) => {
+    if (a.deviceUUID === currentUuid) return -1;
+    if (b.deviceUUID === currentUuid) return 1;
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return (
+      new Date(b.lastUsed || b.lastUpdated || 0) -
+      new Date(a.lastUsed || a.lastUpdated || 0)
+    );
+  });
+
+  const wipeLocalAndLogout = () => {
+    [
+      "biometricsEnabled",
+      "biometricUserId",
+      "lastLoggedInEmail",
+      "pendingNotification",
+    ].forEach((key) => {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // ignore storage errors
+      }
+    });
+    Meteor.logout(() => window.location.replace("/"));
+  };
+
+  const startRename = (device) => {
+    setPageError("");
+    setRenamingUuid(device.deviceUUID);
+    setRenameValue(device.customName || device.deviceModel || "");
+  };
+
+  const saveRename = async (device) => {
+    setPageError("");
+    try {
+      await Meteor.callAsync("devices.rename", {
+        deviceUUID: device.deviceUUID,
+        name: renameValue,
+      });
+      setRenamingUuid(null);
+    } catch (err) {
+      setPageError(err.reason || err.message || "Failed to rename device.");
+    }
+  };
+
+  const setPrimary = async (device) => {
+    setPageError("");
+    try {
+      await Meteor.callAsync("devices.setPrimary", {
+        deviceUUID: device.deviceUUID,
+      });
+    } catch (err) {
+      setPageError(err.reason || err.message || "Failed to update device.");
+    }
+  };
+
+  const requestRevoke = (device) => {
+    const isCurrent = device.deviceUUID === currentUuid;
+    const isLast = devices.length === 1;
+    setActionError("");
+    setPendingAction({
+      type: "revoke",
+      device,
+      title: `Remove "${deviceLabel(device)}"?`,
+      description:
+        "This device will no longer receive authentication requests and will be signed out.",
+      warning: isLast
+        ? "This is your only device. Removing it deregisters your account entirely — you will need to register again and be re-approved by an administrator."
+        : isCurrent
+          ? "You are removing the device you are currently using. You will be signed out immediately."
+          : "Your other devices will be signed out and will need to sign in again.",
+      confirmLabel: "Remove device",
+    });
+  };
+
+  const requestPendingResponse = (device, approve) => {
+    setActionError("");
+    setPendingAction({
+      type: approve ? "approve" : "reject",
+      device,
+      title: approve
+        ? `Approve "${deviceLabel(device)}"?`
+        : `Reject "${deviceLabel(device)}"?`,
+      description: approve
+        ? "This device will be able to receive and respond to authentication requests for your account."
+        : "This device's registration request will be rejected and removed.",
+      warning: approve
+        ? "Only approve devices you recognize and control. If you don't recognize this device, reject it."
+        : null,
+      confirmLabel: approve ? "Approve device" : "Reject device",
+    });
+  };
+
+  const runPendingAction = async (reAuth) => {
+    if (!pendingAction || !currentUuid) return;
+    setBusy(true);
+    setActionError("");
+    try {
+      if (pendingAction.type === "revoke") {
+        const result = await Meteor.callAsync("devices.revoke", {
+          deviceUUID: pendingAction.device.deviceUUID,
+          actorDeviceUUID: currentUuid,
+          reAuth,
+        });
+        if (
+          result.accountRemoved ||
+          pendingAction.device.deviceUUID === currentUuid
+        ) {
+          wipeLocalAndLogout();
+          return;
+        }
+      } else {
+        await Meteor.callAsync("devices.approvePending", {
+          deviceUUID: pendingAction.device.deviceUUID,
+          actorDeviceUUID: currentUuid,
+          approve: pendingAction.type === "approve",
+          reAuth,
+        });
+      }
+      setPendingAction(null);
+    } catch (err) {
+      setActionError(err.reason || err.message || "Action failed.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="relative z-50 bg-card shadow-sm sm:sticky sm:top-0">
+        <div className="px-4 py-2.5 flex items-center gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(-1)}
+            aria-label="Back"
+            className="p-2 rounded-xl h-auto"
+          >
+            <ArrowLeft className="h-5 w-5 text-muted-foreground" />
+          </Button>
+          <h2 className="text-base font-bold text-foreground">My Devices</h2>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-6 space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Devices registered to your account. Removing a device requires
+          verifying it&apos;s you.
+        </p>
+
+        {pageError && (
+          <Alert variant="error">
+            <AlertDescription>{pageError}</AlertDescription>
+          </Alert>
+        )}
+
+        {!currentUuid && (
+          <Alert variant="warning">
+            <AlertDescription>
+              Device identity is unavailable, so device actions are disabled.
+              Please restart the app and try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center py-10">
+            <Spinner size="lg" />
+          </div>
+        ) : sortedDevices.length === 0 ? (
+          <Card>
+            <CardContent className="p-5 text-sm text-muted-foreground">
+              No devices are registered to your account.
+            </CardContent>
+          </Card>
+        ) : (
+          sortedDevices.map((device) => {
+            const isCurrent = device.deviceUUID === currentUuid;
+            const status =
+              STATUS_BADGES[device.deviceRegistrationStatus] ||
+              STATUS_BADGES.rejected;
+            const isRenaming = renamingUuid === device.deviceUUID;
+
+            return (
+              <Card key={device.deviceUUID}>
+                <CardContent className="space-y-3 p-4">
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10">
+                      <Smartphone className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      {isRenaming ? (
+                        <div className="flex items-center gap-1.5">
+                          <Input
+                            value={renameValue}
+                            onChange={(e) => setRenameValue(e.target.value)}
+                            maxLength={40}
+                            autoFocus
+                          />
+                          <Button
+                            variant="ghost"
+                            aria-label="Save name"
+                            className="p-2 h-auto"
+                            onClick={() => saveRename(device)}
+                          >
+                            <Check className="h-4 w-4 text-emerald-500" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            aria-label="Cancel rename"
+                            className="p-2 h-auto"
+                            onClick={() => setRenamingUuid(null)}
+                          >
+                            <X className="h-4 w-4 text-muted-foreground" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <h3 className="text-sm font-semibold text-foreground truncate">
+                            {deviceLabel(device)}
+                          </h3>
+                          {device.isPrimary && (
+                            <Star
+                              className="h-3.5 w-3.5 shrink-0 text-amber-500 fill-amber-500"
+                              aria-label="Primary device"
+                            />
+                          )}
+                          <Button
+                            variant="ghost"
+                            aria-label="Rename device"
+                            className="p-1.5 h-auto"
+                            onClick={() => startRename(device)}
+                          >
+                            <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                          </Button>
+                        </div>
+                      )}
+                      <p className="text-xs text-muted-foreground truncate">
+                        {device.devicePlatform || "Unknown platform"}
+                        {device.deviceModel && device.customName
+                          ? ` · ${device.deviceModel}`
+                          : ""}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Last used: {formatLastUsed(device)}
+                      </p>
+                    </div>
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      <Badge variant={status.variant} size="sm">
+                        {status.label}
+                      </Badge>
+                      {isCurrent && (
+                        <Badge variant="secondary" size="sm">
+                          This device
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {device.deviceRegistrationStatus === "pending" ? (
+                      <>
+                        <Button
+                          size="sm"
+                          disabled={!currentUuid || isCurrent}
+                          onClick={() => requestPendingResponse(device, true)}
+                        >
+                          <ShieldCheck className="h-4 w-4 mr-1.5" />
+                          Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-destructive"
+                          disabled={!currentUuid || isCurrent}
+                          onClick={() => requestPendingResponse(device, false)}
+                        >
+                          Reject
+                        </Button>
+                      </>
+                    ) : (
+                      !device.isPrimary &&
+                      device.deviceRegistrationStatus === "approved" && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={!currentUuid}
+                          onClick={() => setPrimary(device)}
+                        >
+                          <Star className="h-4 w-4 mr-1.5" />
+                          Make primary
+                        </Button>
+                      )
+                    )}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive ml-auto"
+                      disabled={!currentUuid}
+                      onClick={() => requestRevoke(device)}
+                    >
+                      <Trash2 className="h-4 w-4 mr-1.5" />
+                      Remove
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </main>
+
+      {pendingAction && (
+        <ConfirmActionModal
+          action={pendingAction}
+          busy={busy}
+          error={actionError}
+          onClose={() => {
+            setPendingAction(null);
+            setActionError("");
+          }}
+          onConfirm={runPendingAction}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DeviceManagementPage;

--- a/client/mobile/src/ui/LandingPage.jsx
+++ b/client/mobile/src/ui/LandingPage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { openExternal } from "../../../../utils/openExternal";
@@ -51,6 +51,19 @@ export const LandingPage = () => {
 
   const { isDarkMode, toggleDarkMode } = useDarkMode();
   useSessionTimeout();
+
+  // Self-report this device's live OS info once per dashboard load so the
+  // server record heals "Unknown" model/platform placeholders and updates
+  // last-used — which is what the My Devices page (on every device) shows.
+  useEffect(() => {
+    const info = Session.get("capturedDeviceInfo");
+    if (!userId || !info?.uuid) return;
+    Meteor.call("devices.updateInfo", {
+      deviceUUID: info.uuid,
+      deviceModel: info.model,
+      devicePlatform: info.platform,
+    });
+  }, [userId]);
 
   const {
     profile,

--- a/client/mobile/src/ui/LandingPage.jsx
+++ b/client/mobile/src/ui/LandingPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
+import { useTracker } from "meteor/react-meteor-data";
 import { openExternal } from "../../../../utils/openExternal";
 
 // Import Hooks
@@ -14,6 +15,7 @@ import { useSessionTimeout } from "./hooks/useSessionTimeout";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { ProfileSection } from "./components/ProfileSection";
 import { NotificationList } from "./components/NotificationList";
+import SuccessToaster from "./Toasters/SuccessToaster";
 import Pagination from "./Pagination/Pagination";
 import ActionsModal from "./Modal/ActionsModal";
 import ResultModal from "./Modal/ResultModal";
@@ -51,6 +53,11 @@ export const LandingPage = () => {
 
   const { isDarkMode, toggleDarkMode } = useDarkMode();
   useSessionTimeout();
+
+  // Device-trust push received while the app is open (set by
+  // push-notifications.js) — shown as a toast since iOS foreground pushes
+  // have no OS banner.
+  const trustNotice = useTracker(() => Session.get("deviceTrustNotice"), []);
 
   // Self-report this device's live OS info once per dashboard load so the
   // server record heals "Unknown" model/platform placeholders and updates
@@ -149,6 +156,10 @@ export const LandingPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SuccessToaster
+        message={trustNotice?.message || ""}
+        onClose={() => Session.set("deviceTrustNotice", null)}
+      />
       <DashboardHeader
         title="MIE Auth"
         isDarkMode={isDarkMode}

--- a/client/mobile/src/ui/components/AppRoutes.jsx
+++ b/client/mobile/src/ui/components/AppRoutes.jsx
@@ -29,6 +29,7 @@ const BiometricRegistrationModal = lazy(() =>
   })),
 );
 const NotificationSettings = lazy(() => import("../NotificationSettings"));
+const DeviceManagementPage = lazy(() => import("../DeviceManagementPage"));
 
 // --- Lazy-loaded web pages ---
 const WebLandingPage = lazy(() =>
@@ -180,6 +181,18 @@ export const AppRoutes = ({ isRegistered, deviceUuid }) => {
                 isMobile ? (
                   <ProtectedRoute>
                     <NotificationSettings />
+                  </ProtectedRoute>
+                ) : (
+                  <MobileAppRequired />
+                )
+              }
+            />
+            <Route
+              path="/settings/devices"
+              element={
+                isMobile ? (
+                  <ProtectedRoute>
+                    <DeviceManagementPage />
                   </ProtectedRoute>
                 ) : (
                   <MobileAppRequired />

--- a/client/mobile/src/ui/components/DashboardHeader.jsx
+++ b/client/mobile/src/ui/components/DashboardHeader.jsx
@@ -10,6 +10,7 @@ import {
   BellRing,
   MoreVertical,
   ChevronDown,
+  Smartphone,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { openSupportLink } from "../../../../../utils/openExternal";
@@ -140,6 +141,12 @@ export const DashboardHeader = ({
                 </Button>
               }
             >
+              <DropdownItem
+                icon={<Smartphone className="h-4 w-4" />}
+                onClick={() => navigate("/settings/devices")}
+              >
+                My devices
+              </DropdownItem>
               <DropdownItem
                 icon={<Bell className="h-4 w-4" />}
                 onClick={() => navigate("/settings/notifications")}

--- a/client/mobile/src/ui/hooks/useDeviceRegistration.js
+++ b/client/mobile/src/ui/hooks/useDeviceRegistration.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
-import { DeviceDetails } from "../../../../../utils/api/deviceDetails";
 
 export const useDeviceRegistration = () => {
   const [capturedDeviceUuid, setCapturedDeviceUuid] = useState(null);
@@ -10,6 +9,12 @@ export const useDeviceRegistration = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    let lastCheckedUuid = null;
+
+    // Uses the devices.checkRegistrationByUUID method instead of subscribing
+    // to a publication: a second subscription over DeviceDetails published a
+    // conflicting projection of the `devices` field and clobbered the full
+    // device list in Minimongo (DDP merges top-level fields only).
     const sessionTracker = Tracker.autorun(() => {
       const deviceInfo = Session.get("capturedDeviceInfo");
 
@@ -21,31 +26,17 @@ export const useDeviceRegistration = () => {
       }
       setCapturedDeviceUuid(deviceInfo.uuid);
 
-      const subscriber = Meteor.subscribe(
-        "deviceDetails.byDevice",
-        deviceInfo.uuid,
-        {
-          onStop: (error) => {
-            if (error) {
-              setIsLoading(false);
-            }
-          },
-          onReady: () => {
-            const deviceDetailsDoc = DeviceDetails.findOne({
-              "devices.deviceUUID": deviceInfo.uuid,
-            });
+      if (deviceInfo.uuid === lastCheckedUuid) return;
+      lastCheckedUuid = deviceInfo.uuid;
 
-            setBoolRegisteredDevice(!!deviceDetailsDoc);
-            setIsLoading(false);
-          },
+      Meteor.call(
+        "devices.checkRegistrationByUUID",
+        deviceInfo.uuid,
+        (error, result) => {
+          setBoolRegisteredDevice(!error && !!result?.registered);
+          setIsLoading(false);
         },
       );
-
-      return () => {
-        if (subscriber) {
-          subscriber.stop();
-        }
-      };
     });
 
     return () => {

--- a/client/mobile/src/ui/hooks/useUserProfile.js
+++ b/client/mobile/src/ui/hooks/useUserProfile.js
@@ -60,23 +60,30 @@ export const useUserProfile = () => {
     setErrorMessage("");
 
     try {
-      await Meteor.callAsync("user.updateProfile", initialProfile._id, {
+      await Meteor.callAsync("updateUserProfile", {
         firstName: profile.firstName,
         lastName: profile.lastName,
-        // Maybe email updates should be handled differently?
-        // email: profile.email,
+        email: profile.email,
       });
+
+      // Keep the in-memory session profile in sync so the dashboard greeting
+      // reflects the new name without a reload.
+      const current = Session.get("userProfile") || {};
+      Session.set("userProfile", {
+        ...current,
+        firstName: profile.firstName,
+        lastName: profile.lastName,
+      });
+
       setSuccessMessage("Profile updated successfully!");
       setIsEditing(false);
-      // Optionally re-fetch profile or update Session
-    } catch {
-      setErrorMessage("Failed to update profile. Please try again.");
+      setTimeout(() => setSuccessMessage(""), 3000);
+    } catch (error) {
+      setErrorMessage(
+        error?.reason || error?.message || "Failed to update profile.",
+      );
     } finally {
       setIsSaving(false);
-      // Auto-dismiss success message
-      if (successMessage) {
-        setTimeout(() => setSuccessMessage(""), 3000);
-      }
     }
   };
 
@@ -94,41 +101,3 @@ export const useUserProfile = () => {
     setSuccessMessage, // Expose setter if needed externally (e.g., for Toaster)
   };
 };
-
-// Note: Assumes a Meteor method 'user.updateProfile' exists on the server.
-// You might need to create this method in your server-side code.
-// Example server-side method (place in imports/api or server/main.js):
-/*
-Meteor.methods({
-  'user.updateProfile': async function(userId, profileData) {
-    check(userId, String);
-    check(profileData, {
-      firstName: String,
-      lastName: String,
-      // email: Match.Optional(String) // Handle email updates carefully
-    });
-
-    // Add validation/permission checks here if needed
-    if (!this.userId || this.userId !== userId) {
-      throw new Meteor.Error('not-authorized', 'You are not authorized to update this profile.');
-    }
-
-    try {
-      const result = await DeviceDetails.updateAsync(
-        { userId: userId }, 
-        { $set: { 
-            firstName: profileData.firstName,
-            lastName: profileData.lastName,
-            // email: profileData.email, // Be cautious about updating email directly
-            lastUpdated: new Date()
-          }
-        }
-      );
-      return result > 0;
-    } catch (error) {
-      console.error("Error in user.updateProfile method:", error);
-      throw new Meteor.Error('update-failed', 'Could not update profile.');
-    }
-  }
-});
-*/

--- a/client/mobile/src/ui/hooks/useUserProfile.js
+++ b/client/mobile/src/ui/hooks/useUserProfile.js
@@ -1,13 +1,14 @@
 import { useState, useEffect } from "react";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
+import { useTracker } from "meteor/react-meteor-data";
 import { DeviceDetails } from "../../../../../utils/api/deviceDetails";
 
 export const useUserProfile = () => {
   const initialProfile = Session.get("userProfile") || {};
   const [profile, setProfile] = useState({
-    firstName: "",
-    lastName: "",
+    firstName: initialProfile.firstName || "",
+    lastName: initialProfile.lastName || "",
     email: initialProfile.email || "",
   });
   const [isEditing, setIsEditing] = useState(false);
@@ -15,38 +16,25 @@ export const useUserProfile = () => {
   const [successMessage, setSuccessMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  // Fetch user details on mount
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchUserDetails = async () => {
-      if (!initialProfile._id) return;
-      try {
-        const userDoc = await DeviceDetails.findOneAsync({
-          userId: initialProfile._id,
-        });
-        if (isMounted && userDoc) {
-          setProfile({
-            firstName: userDoc.firstName || "",
-            lastName: userDoc.lastName || "",
-            email: userDoc.email || "",
-          });
-        } else if (isMounted) {
-          setErrorMessage("User profile not found.");
-        }
-      } catch {
-        if (isMounted) {
-          setErrorMessage("Failed to fetch profile.");
-        }
-      }
-    };
-
-    fetchUserDetails();
-
-    return () => {
-      isMounted = false;
-    };
+  // Reactive profile source: subscribe to the user's own device document and
+  // re-run whenever it arrives/changes. (A one-shot Minimongo read at mount
+  // races the subscription and misses the data, showing "User" forever.)
+  const userDoc = useTracker(() => {
+    if (!initialProfile._id) return null;
+    Meteor.subscribe("deviceDetails.byUser", initialProfile._id);
+    return DeviceDetails.findOne({ userId: initialProfile._id });
   }, [initialProfile._id]);
+
+  useEffect(() => {
+    // Don't clobber in-progress edits with a reactive refresh.
+    if (!userDoc || isEditing) return;
+    setProfile({
+      firstName: userDoc.firstName || "",
+      lastName: userDoc.lastName || "",
+      email: userDoc.email || initialProfile.email || "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userDoc?.firstName, userDoc?.lastName, userDoc?.email, isEditing]);
 
   const handleProfileChange = (e) => {
     const { name, value } = e.target;

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -42,6 +42,12 @@ const DEVICE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 '._-]{0,39}$/;
 // How long the current primary device has to approve a primary transfer.
 const PRIMARY_TRANSFER_TIMEOUT_MS = 25000;
 
+// Delay before the "primary changed" notice is pushed. The initiating user
+// usually has the app OPEN when the change happens, and iOS shows no OS
+// banner for foreground pushes — the delay gives them time to background the
+// app so the confirmation arrives as a visible system notification.
+const PRIMARY_CHANGE_NOTICE_DELAY_MS = 10000;
+
 const REAUTH_PATTERN = Match.OneOf(
   { biometricSecret: String },
   { pin: String },
@@ -144,6 +150,15 @@ const notifyDevice = (fcmToken, title, body, data) => {
   }).catch((error) => {
     console.error("Device management notification failed:", error.message);
   });
+};
+
+/**
+ * Informational broadcast to a user's approved devices (fire-and-forget).
+ */
+export const notifyApprovedDevices = (devices, title, body, data) => {
+  (devices || [])
+    .filter((d) => d.deviceRegistrationStatus === "approved")
+    .forEach((d) => notifyDevice(d.fcmToken, title, body, data));
 };
 
 /**
@@ -320,17 +335,19 @@ Meteor.methods({
   /**
    * Mark one of the caller's approved devices as the primary device.
    *
-   * Trust transfer rules:
-   * - If there is no current approved primary, or the request is initiated
-   *   FROM the current primary device, the transfer is immediate.
-   * - Otherwise the CURRENT primary must approve: an actionable push (with
-   *   the notificationId only that device receives) is sent to it and the
-   *   method waits for the response. This stops a newly-added or compromised
-   *   secondary device from silently taking over the primary role.
+   * Trust transfer rules — the change is always confirmed by a human:
+   * - Step-up re-authentication (biometric/PIN) is ALWAYS required, so an
+   *   unlocked-but-unattended phone (or a hijacked session) cannot silently
+   *   change the primary.
+   * - If the request is initiated from a device other than the current
+   *   primary, the CURRENT primary must additionally approve: an actionable
+   *   push (with the notificationId only that device receives) is sent to it
+   *   and the method waits for the response.
    */
-  async "devices.setPrimary"({ deviceUUID, actorDeviceUUID }) {
+  async "devices.setPrimary"({ deviceUUID, actorDeviceUUID, reAuth }) {
     check(deviceUUID, String);
     check(actorDeviceUUID, String);
+    check(reAuth, REAUTH_PATTERN);
     requireLogin(this);
 
     const userDoc = await getUserDevicesOrThrow(this.userId);
@@ -346,6 +363,9 @@ Meteor.methods({
     if (device.isPrimary) {
       return { success: true, approved: true };
     }
+
+    // Confirm the human at the initiating device before any trust change.
+    await verifyStepUpAuth(this.userId, reAuth);
 
     // Single atomic update so exactly one device ends up primary.
     const promote = async () => {
@@ -366,24 +386,21 @@ Meteor.methods({
         },
       );
 
-      // Announce the trust change on every other approved device (the
-      // initiating device sees the result in the UI). Purely informational —
-      // no appId/actions, so the client never treats it as an approval
-      // request. If this wasn't the account owner, they find out immediately.
-      userDoc.devices
-        .filter(
-          (d) =>
-            d.deviceRegistrationStatus === "approved" &&
-            d.deviceUUID !== actorDeviceUUID,
-        )
-        .forEach((d) => {
-          notifyDevice(
-            d.fcmToken,
-            "Primary Device Changed",
-            `"${deviceLabel(device)}" is now the primary device for your account. If this wasn't you, contact your administrator.`,
-            { notificationType: "primary_changed" },
-          );
-        });
+      // Announce the trust change on EVERY approved device — including the
+      // initiating one, so the account owner always gets a record of the
+      // change on each device. Purely informational (no appId/actions).
+      // Sent after a short delay so users can background the app and get a
+      // visible OS banner (iOS shows none for foreground pushes); a device
+      // that still has the app open shows an in-app toast instead.
+      const recipients = userDoc.devices;
+      Meteor.setTimeout(() => {
+        notifyApprovedDevices(
+          recipients,
+          "Primary Device Changed",
+          `"${deviceLabel(device)}" is now the primary device for your account. If this wasn't you, contact your administrator.`,
+          { notificationType: "primary_changed" },
+        );
+      }, PRIMARY_CHANGE_NOTICE_DELAY_MS);
     };
 
     const currentPrimary = userDoc.devices.find(
@@ -707,6 +724,17 @@ Meteor.methods({
         status: approve ? "approved" : "rejected",
       },
     );
+
+    // A new trusted device joined the account — tell every other registered
+    // device so the owner learns about the addition immediately.
+    if (approve) {
+      notifyApprovedDevices(
+        userDoc.devices.filter((d) => d.deviceUUID !== deviceUUID),
+        "New Device Added",
+        `"${deviceLabel(target)}" was added to your account. If this wasn't you, contact your administrator.`,
+        { notificationType: "device_added_info" },
+      );
+    }
 
     await logDeviceAudit({
       userId: this.userId,

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -191,6 +191,37 @@ const invalidateOtherSessions = async (userId, connection) => {
 
 Meteor.methods({
   /**
+   * Pre-login check: is this device registered, and what is its status?
+   *
+   * Replaces the old `deviceDetails.byDevice` publication. That publication
+   * published a stripped projection of the same top-level `devices` field as
+   * `deviceDetails.byUser`; Meteor's DDP merge box only tracks TOP-LEVEL
+   * fields, so whichever publication ran first clobbered the other and the
+   * device list rendered with missing fields (model/platform/isPrimary/
+   * lastUsed all undefined). A method has no Minimongo footprint, so no
+   * conflict. Exposes only existence + status — no identifiers or secrets.
+   */
+  async "devices.checkRegistrationByUUID"(deviceUUID) {
+    check(deviceUUID, String);
+
+    const userDoc = await DeviceDetails.findOneAsync(
+      { "devices.deviceUUID": deviceUUID },
+      {
+        fields: {
+          "devices.deviceUUID": 1,
+          "devices.deviceRegistrationStatus": 1,
+        },
+      },
+    );
+    const device = userDoc?.devices?.find((d) => d.deviceUUID === deviceUUID);
+
+    return {
+      registered: !!device,
+      status: device?.deviceRegistrationStatus || null,
+    };
+  },
+
+  /**
    * Self-report the calling device's live OS info (model/platform) and mark
    * it as recently used. Called on dashboard load so records registered with
    * "Unknown" placeholders heal themselves, and other devices see real names.
@@ -508,6 +539,7 @@ Meteor.methods({
 const RATE_LIMITED_METHODS = new Set([
   "users.loginWithBiometric",
   "users.register",
+  "devices.checkRegistrationByUUID",
   "devices.updateInfo",
   "devices.rename",
   "devices.setPrimary",

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -365,6 +365,25 @@ Meteor.methods({
           ],
         },
       );
+
+      // Announce the trust change on every other approved device (the
+      // initiating device sees the result in the UI). Purely informational —
+      // no appId/actions, so the client never treats it as an approval
+      // request. If this wasn't the account owner, they find out immediately.
+      userDoc.devices
+        .filter(
+          (d) =>
+            d.deviceRegistrationStatus === "approved" &&
+            d.deviceUUID !== actorDeviceUUID,
+        )
+        .forEach((d) => {
+          notifyDevice(
+            d.fcmToken,
+            "Primary Device Changed",
+            `"${deviceLabel(device)}" is now the primary device for your account. If this wasn't you, contact your administrator.`,
+            { notificationType: "primary_changed" },
+          );
+        });
     };
 
     const currentPrimary = userDoc.devices.find(

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -410,13 +410,19 @@ Meteor.methods({
     );
 
     // Keep the invariant that one device is primary (device approval pushes
-    // are routed to the primary device).
+    // are routed to the primary device). Guarded so a concurrent revoke /
+    // setPrimary interleaving cannot produce two primaries: the successor is
+    // only promoted if no primary device exists at write time.
     if (target.isPrimary) {
       const successor =
         remaining.find((d) => d.deviceRegistrationStatus === "approved") ||
         remaining[0];
       await DeviceDetails.updateAsync(
-        { userId: this.userId, "devices.deviceUUID": successor.deviceUUID },
+        {
+          userId: this.userId,
+          "devices.deviceUUID": successor.deviceUUID,
+          devices: { $not: { $elemMatch: { isPrimary: true } } },
+        },
         {
           $set: {
             "devices.$.isPrimary": true,
@@ -426,7 +432,15 @@ Meteor.methods({
       );
     }
 
-    await invalidateOtherSessions(this.userId, this.connection);
+    // Session invalidation: on a self-revoke the calling device is the one
+    // being removed, so its own token must die too — the client-side wipe is
+    // only best-effort. Revoking a *different* device keeps the caller's
+    // session and drops everything else.
+    const isSelfRevoke = deviceUUID === actorDeviceUUID;
+    await invalidateOtherSessions(
+      this.userId,
+      isSelfRevoke ? null : this.connection,
+    );
 
     // Courtesy notice on the user's other approved devices.
     remaining

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -191,6 +191,56 @@ const invalidateOtherSessions = async (userId, connection) => {
 
 Meteor.methods({
   /**
+   * Self-report the calling device's live OS info (model/platform) and mark
+   * it as recently used. Called on dashboard load so records registered with
+   * "Unknown" placeholders heal themselves, and other devices see real names.
+   *
+   * Also repairs the primary-device invariant: if the account has approved
+   * devices but none is flagged primary (legacy re-registrations cleared the
+   * flag), the oldest approved device is promoted.
+   */
+  async "devices.updateInfo"({ deviceUUID, deviceModel, devicePlatform }) {
+    check(deviceUUID, String);
+    check(deviceModel, Match.Maybe(String));
+    check(devicePlatform, Match.Maybe(String));
+    requireLogin(this);
+
+    const userDoc = await getUserDevicesOrThrow(this.userId);
+    findOwnedDeviceOrThrow(userDoc, deviceUUID);
+
+    const updates = { "devices.$.lastUsed": new Date() };
+    const clean = (v) => (v || "").toString().trim().slice(0, 64);
+    if (clean(deviceModel))
+      updates["devices.$.deviceModel"] = clean(deviceModel);
+    if (clean(devicePlatform))
+      updates["devices.$.devicePlatform"] = clean(devicePlatform);
+
+    await DeviceDetails.updateAsync(
+      { userId: this.userId, "devices.deviceUUID": deviceUUID },
+      { $set: updates },
+    );
+
+    // Primary invariant repair.
+    const approved = userDoc.devices.filter(
+      (d) => d.deviceRegistrationStatus === "approved",
+    );
+    if (approved.length > 0 && !approved.some((d) => d.isPrimary)) {
+      const oldest = approved.reduce((a, b) =>
+        new Date(a.lastUpdated || 0) <= new Date(b.lastUpdated || 0) ? a : b,
+      );
+      await DeviceDetails.updateAsync(
+        { userId: this.userId, "devices.deviceUUID": oldest.deviceUUID },
+        { $set: { "devices.$.isPrimary": true } },
+      );
+      console.log(
+        `Primary invariant repaired for user ${this.userId}: promoted ${oldest.deviceUUID}`,
+      );
+    }
+
+    return { success: true };
+  },
+
+  /**
    * Rename one of the caller's own devices.
    */
   async "devices.rename"({ deviceUUID, name }) {
@@ -458,6 +508,7 @@ Meteor.methods({
 const RATE_LIMITED_METHODS = new Set([
   "users.loginWithBiometric",
   "users.register",
+  "devices.updateInfo",
   "devices.rename",
   "devices.setPrimary",
   "devices.revoke",

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -6,6 +6,9 @@ import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
 import crypto from "crypto";
 import { DeviceDetails } from "../utils/api/deviceDetails.js";
 import { ApprovalTokens } from "../utils/api/approvalTokens";
+import "../utils/api/notificationHistory.js"; // Method registration (primary-transfer approvals)
+import "../utils/api/pendingResponses.js"; // Method registration (primary-transfer approvals)
+import { APPROVAL_ACTIONS } from "../utils/constants.js";
 import { sendNotification } from "./firebase.js";
 
 /**
@@ -35,6 +38,9 @@ Meteor.startup(() => {
 
 // 1-40 chars; letters, numbers, spaces and ' . _ - (must start alphanumeric).
 const DEVICE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 '._-]{0,39}$/;
+
+// How long the current primary device has to approve a primary transfer.
+const PRIMARY_TRANSFER_TIMEOUT_MS = 25000;
 
 const REAUTH_PATTERN = Match.OneOf(
   { biometricSecret: String },
@@ -313,13 +319,23 @@ Meteor.methods({
 
   /**
    * Mark one of the caller's approved devices as the primary device.
+   *
+   * Trust transfer rules:
+   * - If there is no current approved primary, or the request is initiated
+   *   FROM the current primary device, the transfer is immediate.
+   * - Otherwise the CURRENT primary must approve: an actionable push (with
+   *   the notificationId only that device receives) is sent to it and the
+   *   method waits for the response. This stops a newly-added or compromised
+   *   secondary device from silently taking over the primary role.
    */
-  async "devices.setPrimary"({ deviceUUID }) {
+  async "devices.setPrimary"({ deviceUUID, actorDeviceUUID }) {
     check(deviceUUID, String);
+    check(actorDeviceUUID, String);
     requireLogin(this);
 
     const userDoc = await getUserDevicesOrThrow(this.userId);
     const device = findOwnedDeviceOrThrow(userDoc, deviceUUID);
+    findOwnedDeviceOrThrow(userDoc, actorDeviceUUID);
 
     if (device.deviceRegistrationStatus !== "approved") {
       throw new Meteor.Error(
@@ -327,32 +343,150 @@ Meteor.methods({
         "Only an approved device can be made primary.",
       );
     }
+    if (device.isPrimary) {
+      return { success: true, approved: true };
+    }
 
     // Single atomic update so exactly one device ends up primary.
-    await DeviceDetails.rawCollection().updateOne(
-      { userId: this.userId },
-      {
-        $set: {
-          "devices.$[target].isPrimary": true,
-          "devices.$[others].isPrimary": false,
-          lastUpdated: new Date(),
+    const promote = async () => {
+      await DeviceDetails.rawCollection().updateOne(
+        { userId: this.userId },
+        {
+          $set: {
+            "devices.$[target].isPrimary": true,
+            "devices.$[others].isPrimary": false,
+            lastUpdated: new Date(),
+          },
         },
-      },
+        {
+          arrayFilters: [
+            { "target.deviceUUID": deviceUUID },
+            { "others.deviceUUID": { $ne: deviceUUID } },
+          ],
+        },
+      );
+    };
+
+    const currentPrimary = userDoc.devices.find(
+      (d) => d.isPrimary && d.deviceRegistrationStatus === "approved",
+    );
+
+    // Direct transfer: nothing to protect, or initiated from the primary
+    // device itself (which is exactly the trusted party we would ask).
+    if (!currentPrimary || currentPrimary.deviceUUID === actorDeviceUUID) {
+      await promote();
+      await logDeviceAudit({
+        userId: this.userId,
+        action: "setPrimary",
+        deviceUUID,
+        actorDeviceUUID,
+      });
+      return { success: true, approved: true };
+    }
+
+    // Approval required from the current primary device.
+    const user = await Meteor.users.findOneAsync(this.userId);
+    if (!user?.username) {
+      throw new Meteor.Error("not-found", "Account not found.");
+    }
+
+    const title = "Primary Device Change Request";
+    const body = `"${deviceLabel(device)}" is requesting to become the primary device for your account.`;
+
+    // The notificationId is delivered ONLY in the push to the current
+    // primary device, so only that device can respond to this request
+    // (notifications.handleResponse additionally enforces account ownership
+    // and approved-device status).
+    const notificationId = await Meteor.callAsync(
+      "notificationHistory.insert",
       {
-        arrayFilters: [
-          { "target.deviceUUID": deviceUUID },
-          { "others.deviceUUID": { $ne: deviceUUID } },
-        ],
+        userId: this.userId,
+        title,
+        body,
+        appId: currentPrimary.appId,
       },
     );
+    if (!notificationId) {
+      throw new Meteor.Error(
+        "primary-unreachable",
+        "Could not create the approval request. Please try again.",
+      );
+    }
+
+    await Meteor.callAsync(
+      "pendingResponses.create",
+      user.username,
+      notificationId,
+      PRIMARY_TRANSFER_TIMEOUT_MS,
+    );
+
+    let sent = null;
+    try {
+      sent = await sendNotification(currentPrimary.fcmToken, title, body, {
+        notificationType: "approval",
+        userId: this.userId,
+        notificationId,
+        appId: currentPrimary.appId,
+        actions: JSON.stringify(APPROVAL_ACTIONS),
+        isDismissal: "false",
+        isSync: "false",
+      });
+    } catch (error) {
+      console.error("Primary transfer push failed:", error.message);
+    }
+    if (!sent) {
+      await Meteor.callAsync(
+        "notificationHistory.updateStatus",
+        notificationId,
+        "timeout",
+      );
+      throw new Meteor.Error(
+        "primary-unreachable",
+        "Could not reach your primary device. Make sure it is online and try again.",
+      );
+    }
+
+    const action = await Meteor.callAsync(
+      "pendingResponses.waitForResponse",
+      user.username,
+      notificationId,
+      PRIMARY_TRANSFER_TIMEOUT_MS,
+    );
+
+    if (action === "approve" || action === "approved") {
+      await promote();
+      await logDeviceAudit({
+        userId: this.userId,
+        action: "setPrimary",
+        deviceUUID,
+        actorDeviceUUID,
+        details: `approved by primary ${currentPrimary.deviceUUID}`,
+      });
+      return { success: true, approved: true };
+    }
+
+    if (action === "timeout") {
+      await Meteor.callAsync(
+        "notificationHistory.updateStatus",
+        notificationId,
+        "timeout",
+      );
+      throw new Meteor.Error(
+        "primary-timeout",
+        "Your primary device did not respond. Try again when it is nearby.",
+      );
+    }
 
     await logDeviceAudit({
       userId: this.userId,
-      action: "setPrimary",
+      action: "setPrimaryRejected",
       deviceUUID,
+      actorDeviceUUID,
     });
-
-    return { success: true };
+    throw new Meteor.Error(
+      "primary-rejected",
+      "Your primary device rejected the request.",
+    );
   },
 
   /**
@@ -373,6 +507,23 @@ Meteor.methods({
     const userDoc = await getUserDevicesOrThrow(this.userId);
     const target = findOwnedDeviceOrThrow(userDoc, deviceUUID);
     findOwnedDeviceOrThrow(userDoc, actorDeviceUUID);
+
+    // The primary device (or the only approved device) can never be removed:
+    // the account always keeps at least one trusted device. To remove it,
+    // transfer the primary role to another device first — which requires the
+    // current primary's approval.
+    const approvedCount = userDoc.devices.filter(
+      (d) => d.deviceRegistrationStatus === "approved",
+    ).length;
+    if (
+      target.deviceRegistrationStatus === "approved" &&
+      (target.isPrimary || approvedCount === 1)
+    ) {
+      throw new Meteor.Error(
+        "primary-device-protected",
+        "The primary device cannot be removed. Make another device primary first.",
+      );
+    }
 
     const remaining = userDoc.devices.filter(
       (d) => d.deviceUUID !== deviceUUID,

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -1,0 +1,475 @@
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { Accounts } from "meteor/accounts-base";
+import { check, Match } from "meteor/check";
+import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
+import crypto from "crypto";
+import { DeviceDetails } from "../utils/api/deviceDetails.js";
+import { ApprovalTokens } from "../utils/api/approvalTokens";
+import { sendNotification } from "./firebase.js";
+
+/**
+ * Self-service device management ("My Devices").
+ *
+ * Every method here:
+ *  - requires an authenticated session (this.userId), and
+ *  - operates exclusively on the caller's own DeviceDetails document,
+ * so a user can never read or mutate another user's devices.
+ *
+ * Destructive/trust-changing actions (revoke, approve/reject a pending
+ * device) additionally require step-up re-authentication: the client must
+ * present the device-bound biometric secret (released by the OS only after a
+ * successful biometric prompt) or the account PIN.
+ */
+
+// Insert-only audit trail of self-service device management actions.
+export const DeviceAuditLog = new Mongo.Collection("deviceAuditLog");
+
+Meteor.startup(() => {
+  try {
+    DeviceAuditLog.createIndex({ userId: 1, createdAt: -1 });
+  } catch (error) {
+    console.error("Error creating DeviceAuditLog indexes:", error);
+  }
+});
+
+// 1-40 chars; letters, numbers, spaces and ' . _ - (must start alphanumeric).
+const DEVICE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 '._-]{0,39}$/;
+
+const REAUTH_PATTERN = Match.OneOf(
+  { biometricSecret: String },
+  { pin: String },
+);
+
+/**
+ * Constant-time string comparison (hash first so lengths never leak).
+ */
+const timingSafeEquals = (a, b) => {
+  const hashA = crypto.createHash("sha256").update(String(a)).digest();
+  const hashB = crypto.createHash("sha256").update(String(b)).digest();
+  return crypto.timingSafeEqual(hashA, hashB);
+};
+
+const requireLogin = (context) => {
+  if (!context.userId) {
+    throw new Meteor.Error(
+      "not-authorized",
+      "You must be signed in to manage devices.",
+    );
+  }
+};
+
+/**
+ * Verify step-up re-authentication proof for destructive device actions.
+ * Accepts either the device-bound biometric secret of one of the caller's
+ * approved devices, or the account PIN.
+ */
+const verifyStepUpAuth = async (userId, reAuth) => {
+  if (reAuth.biometricSecret) {
+    const userDoc = await DeviceDetails.findOneAsync({ userId });
+    const verified = (userDoc?.devices || []).some(
+      (device) =>
+        device.deviceRegistrationStatus === "approved" &&
+        device.biometricSecret &&
+        timingSafeEquals(device.biometricSecret, reAuth.biometricSecret),
+    );
+    if (!verified) {
+      throw new Meteor.Error(
+        "reauth-failed",
+        "Biometric verification failed. Please try again.",
+      );
+    }
+    return;
+  }
+
+  const user = await Meteor.users.findOneAsync({ _id: userId });
+  if (!user) {
+    throw new Meteor.Error("reauth-failed", "Account not found.");
+  }
+  const result = await Accounts._checkPasswordAsync(user, reAuth.pin);
+  if (result.error) {
+    throw new Meteor.Error("reauth-failed", "Incorrect PIN. Please try again.");
+  }
+};
+
+const getUserDevicesOrThrow = async (userId) => {
+  const userDoc = await DeviceDetails.findOneAsync({ userId });
+  if (!userDoc || !userDoc.devices?.length) {
+    throw new Meteor.Error(
+      "not-found",
+      "No devices are registered for this account.",
+    );
+  }
+  return userDoc;
+};
+
+const findOwnedDeviceOrThrow = (userDoc, deviceUUID) => {
+  const device = userDoc.devices.find((d) => d.deviceUUID === deviceUUID);
+  if (!device) {
+    throw new Meteor.Error(
+      "device-not-owned",
+      "This device is not registered to your account.",
+    );
+  }
+  return device;
+};
+
+const deviceLabel = (device) =>
+  device.customName ||
+  device.deviceModel ||
+  `Device ${device.deviceUUID.substring(0, 8)}...`;
+
+const logDeviceAudit = async (entry) => {
+  try {
+    await DeviceAuditLog.insertAsync({ ...entry, createdAt: new Date() });
+  } catch (error) {
+    console.error("Failed to write device audit log:", error);
+  }
+};
+
+// Fire-and-forget push; device management must not fail because a courtesy
+// notification could not be delivered.
+const notifyDevice = (fcmToken, title, body, data) => {
+  if (!fcmToken) return;
+  sendNotification(fcmToken, title, body, {
+    isDismissal: "false",
+    isSync: "false",
+    ...data,
+  }).catch((error) => {
+    console.error("Device management notification failed:", error.message);
+  });
+};
+
+/**
+ * Remove a user account and everything attached to it (devices, approval
+ * tokens). Shared by users.removeCompletely and last-device self-revocation.
+ */
+export const removeUserCompletely = async (userId) => {
+  const userRemoved = await Meteor.users.removeAsync({ _id: userId });
+  const deviceRemoved = await DeviceDetails.removeAsync({ userId });
+  const tokensRemoved = await ApprovalTokens.removeAsync({ userId });
+
+  return {
+    success: true,
+    userRemoved: userRemoved > 0,
+    deviceRemoved: deviceRemoved > 0,
+    tokensRemoved: tokensRemoved > 0,
+  };
+};
+
+/**
+ * Invalidate resume login tokens for the caller's account. Meteor login
+ * tokens are not bound to a device, so per-device invalidation is not
+ * possible; instead we drop every session except (optionally) the caller's
+ * current one. Other legitimate devices simply re-authenticate with their
+ * device-bound biometric secret, while a revoked device cannot — its
+ * credentials no longer exist server-side.
+ */
+const invalidateOtherSessions = async (userId, connection) => {
+  const currentHashedToken = connection
+    ? Accounts._getLoginToken(connection.id)
+    : null;
+
+  if (currentHashedToken) {
+    await Meteor.users.updateAsync(
+      { _id: userId },
+      {
+        $pull: {
+          "services.resume.loginTokens": {
+            hashedToken: { $ne: currentHashedToken },
+          },
+        },
+      },
+    );
+  } else {
+    await Meteor.users.updateAsync(
+      { _id: userId },
+      { $set: { "services.resume.loginTokens": [] } },
+    );
+  }
+};
+
+Meteor.methods({
+  /**
+   * Rename one of the caller's own devices.
+   */
+  async "devices.rename"({ deviceUUID, name }) {
+    check(deviceUUID, String);
+    check(name, String);
+    requireLogin(this);
+
+    const trimmedName = name.trim();
+    if (!DEVICE_NAME_PATTERN.test(trimmedName)) {
+      throw new Meteor.Error(
+        "invalid-name",
+        "Device name must be 1-40 characters: letters, numbers, spaces or ' . _ -",
+      );
+    }
+
+    const userDoc = await getUserDevicesOrThrow(this.userId);
+    findOwnedDeviceOrThrow(userDoc, deviceUUID);
+
+    await DeviceDetails.updateAsync(
+      { userId: this.userId, "devices.deviceUUID": deviceUUID },
+      {
+        $set: {
+          "devices.$.customName": trimmedName,
+          "devices.$.lastUpdated": new Date(),
+          lastUpdated: new Date(),
+        },
+      },
+    );
+
+    await logDeviceAudit({
+      userId: this.userId,
+      action: "rename",
+      deviceUUID,
+      details: trimmedName,
+    });
+
+    return { success: true };
+  },
+
+  /**
+   * Mark one of the caller's approved devices as the primary device.
+   */
+  async "devices.setPrimary"({ deviceUUID }) {
+    check(deviceUUID, String);
+    requireLogin(this);
+
+    const userDoc = await getUserDevicesOrThrow(this.userId);
+    const device = findOwnedDeviceOrThrow(userDoc, deviceUUID);
+
+    if (device.deviceRegistrationStatus !== "approved") {
+      throw new Meteor.Error(
+        "device-not-approved",
+        "Only an approved device can be made primary.",
+      );
+    }
+
+    // Single atomic update so exactly one device ends up primary.
+    await DeviceDetails.rawCollection().updateOne(
+      { userId: this.userId },
+      {
+        $set: {
+          "devices.$[target].isPrimary": true,
+          "devices.$[others].isPrimary": false,
+          lastUpdated: new Date(),
+        },
+      },
+      {
+        arrayFilters: [
+          { "target.deviceUUID": deviceUUID },
+          { "others.deviceUUID": { $ne: deviceUUID } },
+        ],
+      },
+    );
+
+    await logDeviceAudit({
+      userId: this.userId,
+      action: "setPrimary",
+      deviceUUID,
+    });
+
+    return { success: true };
+  },
+
+  /**
+   * Revoke (remove) one of the caller's own devices.
+   *
+   * Requires step-up re-authentication. Removing the last device deregisters
+   * the whole account (re-registration then goes through the normal
+   * first-device admin approval flow).
+   */
+  async "devices.revoke"({ deviceUUID, actorDeviceUUID, reAuth }) {
+    check(deviceUUID, String);
+    check(actorDeviceUUID, String);
+    check(reAuth, REAUTH_PATTERN);
+    requireLogin(this);
+
+    await verifyStepUpAuth(this.userId, reAuth);
+
+    const userDoc = await getUserDevicesOrThrow(this.userId);
+    const target = findOwnedDeviceOrThrow(userDoc, deviceUUID);
+    findOwnedDeviceOrThrow(userDoc, actorDeviceUUID);
+
+    const remaining = userDoc.devices.filter(
+      (d) => d.deviceUUID !== deviceUUID,
+    );
+
+    // Tell the revoked device to wipe its local state and sign out. Best
+    // effort — even if the push never arrives, the device can no longer act:
+    // its biometric secret is deleted and its sessions are invalidated below.
+    notifyDevice(
+      target.fcmToken,
+      "Device Removed",
+      "This device has been removed from your MIE Auth account.",
+      { notificationType: "device_revoked" },
+    );
+
+    if (remaining.length === 0) {
+      // Last device: fully deregister the account.
+      const result = await removeUserCompletely(this.userId);
+      await logDeviceAudit({
+        userId: this.userId,
+        action: "revoke",
+        deviceUUID,
+        actorDeviceUUID,
+        details: "last device — account deregistered",
+      });
+      return { ...result, accountRemoved: true };
+    }
+
+    await DeviceDetails.updateAsync(
+      { userId: this.userId },
+      {
+        $pull: { devices: { deviceUUID } },
+        $set: { lastUpdated: new Date() },
+      },
+    );
+
+    // Keep the invariant that one device is primary (device approval pushes
+    // are routed to the primary device).
+    if (target.isPrimary) {
+      const successor =
+        remaining.find((d) => d.deviceRegistrationStatus === "approved") ||
+        remaining[0];
+      await DeviceDetails.updateAsync(
+        { userId: this.userId, "devices.deviceUUID": successor.deviceUUID },
+        {
+          $set: {
+            "devices.$.isPrimary": true,
+            "devices.$.lastUpdated": new Date(),
+          },
+        },
+      );
+    }
+
+    await invalidateOtherSessions(this.userId, this.connection);
+
+    // Courtesy notice on the user's other approved devices.
+    remaining
+      .filter(
+        (d) =>
+          d.deviceRegistrationStatus === "approved" &&
+          d.deviceUUID !== actorDeviceUUID,
+      )
+      .forEach((d) => {
+        notifyDevice(
+          d.fcmToken,
+          "Device Removed",
+          `"${deviceLabel(target)}" was removed from your account. If this wasn't you, contact your administrator.`,
+          { notificationType: "device_removed_info" },
+        );
+      });
+
+    await logDeviceAudit({
+      userId: this.userId,
+      action: "revoke",
+      deviceUUID,
+      actorDeviceUUID,
+      details: deviceLabel(target),
+    });
+
+    return { success: true, accountRemoved: false };
+  },
+
+  /**
+   * Approve or reject one of the caller's own pending devices from an
+   * already-approved device. Requires step-up re-authentication.
+   */
+  async "devices.approvePending"({
+    deviceUUID,
+    actorDeviceUUID,
+    approve,
+    reAuth,
+  }) {
+    check(deviceUUID, String);
+    check(actorDeviceUUID, String);
+    check(approve, Boolean);
+    check(reAuth, REAUTH_PATTERN);
+    requireLogin(this);
+
+    await verifyStepUpAuth(this.userId, reAuth);
+
+    const userDoc = await getUserDevicesOrThrow(this.userId);
+    const target = findOwnedDeviceOrThrow(userDoc, deviceUUID);
+    const actor = findOwnedDeviceOrThrow(userDoc, actorDeviceUUID);
+
+    if (actor.deviceRegistrationStatus !== "approved") {
+      throw new Meteor.Error(
+        "device-not-approved",
+        "Only an approved device can respond to pending device requests.",
+      );
+    }
+    if (target.deviceRegistrationStatus !== "pending") {
+      throw new Meteor.Error(
+        "invalid-status",
+        "This device is not pending approval.",
+      );
+    }
+
+    if (approve) {
+      await DeviceDetails.updateAsync(
+        { userId: this.userId, "devices.deviceUUID": deviceUUID },
+        {
+          $set: {
+            "devices.$.deviceRegistrationStatus": "approved",
+            "devices.$.lastUpdated": new Date(),
+            lastUpdated: new Date(),
+          },
+        },
+      );
+    } else {
+      // Mirror the registration flow: a rejected pending device is removed.
+      await DeviceDetails.updateAsync(
+        { userId: this.userId },
+        {
+          $pull: { devices: { deviceUUID } },
+          $set: { lastUpdated: new Date() },
+        },
+      );
+    }
+
+    notifyDevice(
+      target.fcmToken,
+      approve ? "Device Approved" : "Device Registration Rejected",
+      approve
+        ? "Your device has been approved. You can now use the application."
+        : "Your device registration has been rejected.",
+      {
+        notificationType: "device_approval",
+        status: approve ? "approved" : "rejected",
+      },
+    );
+
+    await logDeviceAudit({
+      userId: this.userId,
+      action: approve ? "approvePending" : "rejectPending",
+      deviceUUID,
+      actorDeviceUUID,
+    });
+
+    return { success: true, approved: approve };
+  },
+});
+
+// Brute-force protection for authentication and device management methods.
+const RATE_LIMITED_METHODS = new Set([
+  "users.loginWithBiometric",
+  "users.register",
+  "devices.rename",
+  "devices.setPrimary",
+  "devices.revoke",
+  "devices.approvePending",
+]);
+
+DDPRateLimiter.addRule(
+  {
+    type: "method",
+    name: (name) => RATE_LIMITED_METHODS.has(name),
+    connectionId: () => true,
+  },
+  10, // max 10 calls
+  60 * 1000, // per minute, per connection
+);

--- a/server/main.js
+++ b/server/main.js
@@ -2016,6 +2016,20 @@ Meteor.methods({
         },
       });
 
+      // Keep the denormalized copy on the device document in sync so the
+      // dashboard/profile (which reads DeviceDetails) reflects the change.
+      await DeviceDetails.updateAsync(
+        { userId: this.userId },
+        {
+          $set: {
+            firstName,
+            lastName,
+            email,
+            lastUpdated: new Date(),
+          },
+        },
+      );
+
       return { success: true, message: "Profile updated successfully" };
     } catch (error) {
       console.error("Error updating profile:", error);

--- a/server/main.js
+++ b/server/main.js
@@ -11,7 +11,10 @@ import {
   getFCMTokensByUsername,
   getApprovedFCMTokensByUserId,
 } from "../utils/api/deviceDetails.js";
-import { removeUserCompletely } from "./deviceManagement.js"; // Also registers self-service device management methods + rate limiting
+import {
+  removeUserCompletely,
+  notifyApprovedDevices,
+} from "./deviceManagement.js"; // Also registers self-service device management methods + rate limiting
 import { NotificationHistory } from "../utils/api/notificationHistory.js";
 import { ApprovalTokens } from "../utils/api/approvalTokens";
 import { PendingResponses } from "../utils/api/pendingResponses.js";
@@ -1890,6 +1893,19 @@ Meteor.methods({
             );
             console.log(
               `Secondary device ${sessionDeviceInfo.uuid} approved and database updated`,
+            );
+
+            // A new trusted device joined the account — tell every other
+            // registered device so the owner learns about the addition
+            // immediately (the new device itself sees the result in-app).
+            const updatedDoc = await DeviceDetails.findOneAsync({ userId });
+            notifyApprovedDevices(
+              (updatedDoc?.devices || []).filter(
+                (d) => d.deviceUUID !== sessionDeviceInfo.uuid,
+              ),
+              "New Device Added",
+              `"${sessionDeviceInfo.model || `Device ${sessionDeviceInfo.uuid.substring(0, 8)}...`}" was added to your account. If this wasn't you, contact your administrator.`,
+              { notificationType: "device_added_info" },
             );
           } else if (
             res === "timeout" ||

--- a/server/main.js
+++ b/server/main.js
@@ -5,7 +5,13 @@ import { sendNotification, sendDeviceApprovalNotification } from "./firebase";
 import { Accounts } from "meteor/accounts-base";
 import { check, Match } from "meteor/check";
 import { Random } from "meteor/random";
-import { DeviceDetails } from "../utils/api/deviceDetails.js";
+import {
+  DeviceDetails,
+  registerDeviceDetails,
+  getFCMTokensByUsername,
+  getApprovedFCMTokensByUserId,
+} from "../utils/api/deviceDetails.js";
+import { removeUserCompletely } from "./deviceManagement.js"; // Also registers self-service device management methods + rate limiting
 import { NotificationHistory } from "../utils/api/notificationHistory.js";
 import { ApprovalTokens } from "../utils/api/approvalTokens";
 import { PendingResponses } from "../utils/api/pendingResponses.js";
@@ -253,10 +259,7 @@ const sendSyncNotificationToDevices = async (
   action,
 ) => {
   try {
-    const fcmTokens = await Meteor.callAsync(
-      "deviceDetails.getApprovedFCMTokensByUserId",
-      userId,
-    );
+    const fcmTokens = await getApprovedFCMTokensByUserId(userId);
     if (!fcmTokens || fcmTokens.length === 0) return;
 
     const syncData = {
@@ -606,20 +609,7 @@ WebApp.connectHandlers.use("/send-notification", (req, res, next) => {
       console.log(`Processing notification for user: ${username}`);
 
       // Get FCM tokens
-      const fcmTokens = await new Promise((resolve, reject) => {
-        Meteor.call(
-          "deviceDetails.getFCMTokenByUsername",
-          username,
-          (error, result) => {
-            if (error) {
-              console.error("Error getting FCM tokens:", error);
-              reject(error);
-            } else {
-              resolve(result);
-            }
-          },
-        );
-      });
+      const fcmTokens = await getFCMTokensByUsername(username);
 
       if (!fcmTokens || fcmTokens.length === 0) {
         console.error(`No FCM tokens found for username: ${username}`);
@@ -1439,6 +1429,12 @@ Meteor.methods({
           "Your device registration is still pending admin approval. You cannot respond to notifications until your device is approved.",
         );
       }
+
+      // Record last activity on the responding device (shown in My Devices).
+      await DeviceDetails.updateAsync(
+        { userId: resolvedUserId, "devices.deviceUUID": respondingDeviceUUID },
+        { $set: { "devices.$.lastUsed": new Date() } },
+      );
     }
 
     const targetNotification = await NotificationHistory.findOneAsync({
@@ -1601,6 +1597,12 @@ Meteor.methods({
     // and establish a real DDP session (this.userId on subsequent method calls).
     const stampedToken = Accounts._generateStampedLoginToken();
     await Accounts._insertLoginToken(user._id, stampedToken);
+
+    // Record last activity on this device (shown in My Devices).
+    await DeviceDetails.updateAsync(
+      { userId: userDoc.userId, "devices.deviceUUID": device.deviceUUID },
+      { $set: { "devices.$.lastUsed": new Date() } },
+    );
 
     // Return necessary user information for the session
     return {
@@ -1771,7 +1773,7 @@ Meteor.methods({
         });
       }
 
-      const deviceResp = await Meteor.callAsync("deviceDetails", {
+      const deviceResp = await registerDeviceDetails({
         username: normalizedRegistration.username,
         biometricSecret,
         userId,
@@ -2103,10 +2105,7 @@ Meteor.methods({
     check(actions, Array);
 
     try {
-      const fcmTokens = await Meteor.callAsync(
-        "deviceDetails.getFCMTokenByUsername",
-        username,
-      );
+      const fcmTokens = await getFCMTokensByUsername(username);
 
       if (!fcmTokens || fcmTokens.length === 0) {
         throw new Meteor.Error("no-devices", "No devices found for user");
@@ -2175,10 +2174,7 @@ Meteor.methods({
 
     let fcmTokens = [];
     try {
-      fcmTokens = await Meteor.callAsync(
-        "deviceDetails.getApprovedFCMTokensByUserId",
-        userId,
-      );
+      fcmTokens = await getApprovedFCMTokensByUserId(userId);
     } catch (error) {
       // The lookup throws "invalid-username" when the user has no device
       // document at all; treat that the same as having no approved devices.
@@ -2345,6 +2341,14 @@ Meteor.methods({
 
     const { userId, primaryDeviceUUID, secondaryDeviceUUID, approved } =
       options;
+
+    // Only the account owner may respond to their own device approval request.
+    if (!this.userId || this.userId !== userId) {
+      throw new Meteor.Error(
+        "not-authorized",
+        "You may only respond to your own device approval requests.",
+      );
+    }
 
     // Find the user and devices
     const userDeviceDoc = await DeviceDetails.findOneAsync({ userId });
@@ -2514,28 +2518,26 @@ Meteor.methods({
   "users.removeCompletely": async function (userId) {
     check(userId, String);
 
+    // Server-internal only: account deletion is driven by trusted server
+    // flows (admin API, Duo admin API, expired-approval cleanup) — never
+    // directly by a client connection.
+    if (this.connection) {
+      throw new Meteor.Error(
+        "not-authorized",
+        "This method can only be called by the server.",
+      );
+    }
+
     console.log(`Completely removing user ${userId}`);
 
     try {
-      // Remove user from Meteor.users collection
-      const userRemoved = await Meteor.users.removeAsync({ _id: userId });
-
-      // Remove user's device details
-      const deviceRemoved = await DeviceDetails.removeAsync({ userId });
-
-      // Remove any pending approval tokens
-      const tokensRemoved = await ApprovalTokens.removeAsync({ userId });
+      const result = await removeUserCompletely(userId);
 
       console.log(
-        `User removal complete - User: ${userRemoved}, Devices: ${deviceRemoved}, Tokens: ${tokensRemoved}`,
+        `User removal complete - User: ${result.userRemoved}, Devices: ${result.deviceRemoved}, Tokens: ${result.tokensRemoved}`,
       );
 
-      return {
-        success: true,
-        userRemoved: userRemoved > 0,
-        deviceRemoved: deviceRemoved > 0,
-        tokensRemoved: tokensRemoved > 0,
-      };
+      return result;
     } catch (error) {
       console.error(`Error removing user ${userId}:`, error);
       throw new Meteor.Error("user-removal-failed", error.message);

--- a/server/main.js
+++ b/server/main.js
@@ -2007,12 +2007,18 @@ Meteor.methods({
     }
 
     try {
+      // Only reset the verified flag when the address actually changes — a
+      // new address must never inherit the old one's verified status.
+      const currentUser = await Meteor.users.findOneAsync(this.userId);
+      const emailChanged = currentUser?.emails?.[0]?.address !== email;
+
       // Update the user's profile in the database
       await Meteor.users.updateAsync(this.userId, {
         $set: {
           "profile.firstName": firstName,
           "profile.lastName": lastName,
           "emails.0.address": email,
+          ...(emailChanged && { "emails.0.verified": false }),
         },
       });
 

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -1,0 +1,375 @@
+import assert from "assert";
+
+if (Meteor.isServer) {
+  describe("Device management (My Devices)", function () {
+    const { DeviceDetails } = require("../utils/api/deviceDetails");
+    const { DeviceAuditLog } = require("../server/deviceManagement");
+
+    const USER_A = "device-mgmt-user-a";
+    const USER_B = "device-mgmt-user-b";
+    const BIO_SECRET = "bio-secret-primary-device";
+
+    const callMethod = (name, context, ...args) =>
+      Meteor.server.method_handlers[name].call(context, ...args);
+
+    const makeDevice = (overrides = {}) => ({
+      deviceUUID: "uuid-primary",
+      appId: "app-primary",
+      biometricSecret: BIO_SECRET,
+      fcmToken: "fcm-primary",
+      deviceModel: "iPhone 15",
+      devicePlatform: "iOS",
+      isFirstDevice: true,
+      isPrimary: true,
+      isSecondaryDevice: false,
+      deviceRegistrationStatus: "approved",
+      lastUpdated: new Date(),
+      ...overrides,
+    });
+
+    beforeEach(async function () {
+      await DeviceDetails.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+      await DeviceAuditLog.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+
+      await DeviceDetails.insertAsync({
+        userId: USER_A,
+        username: "usera",
+        email: "usera@example.com",
+        devices: [
+          makeDevice(),
+          makeDevice({
+            deviceUUID: "uuid-secondary",
+            appId: "app-secondary",
+            biometricSecret: "bio-secret-secondary",
+            fcmToken: "fcm-secondary",
+            deviceModel: "Pixel 9",
+            devicePlatform: "Android",
+            isFirstDevice: false,
+            isPrimary: false,
+            isSecondaryDevice: true,
+          }),
+        ],
+        createdAt: new Date(),
+        lastUpdated: new Date(),
+      });
+    });
+
+    afterEach(async function () {
+      await DeviceDetails.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+      await DeviceAuditLog.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+    });
+
+    describe("devices.rename", function () {
+      it("rejects unauthenticated callers", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.rename",
+            { userId: null },
+            {
+              deviceUUID: "uuid-primary",
+              name: "My Phone",
+            },
+          ),
+          /not-authorized/,
+        );
+      });
+
+      it("rejects invalid names", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.rename",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-primary",
+              name: "  <script>  ",
+            },
+          ),
+          /invalid-name/,
+        );
+      });
+
+      it("rejects renaming a device the caller does not own", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.rename",
+            { userId: USER_B },
+            {
+              deviceUUID: "uuid-primary",
+              name: "Hijack",
+            },
+          ),
+          /not-found/,
+        );
+      });
+
+      it("renames the caller's own device", async function () {
+        await callMethod(
+          "devices.rename",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-primary",
+            name: "Work Phone",
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-primary");
+        assert.strictEqual(device.customName, "Work Phone");
+      });
+    });
+
+    describe("devices.setPrimary", function () {
+      it("rejects non-approved devices", async function () {
+        await DeviceDetails.updateAsync(
+          { userId: USER_A, "devices.deviceUUID": "uuid-secondary" },
+          { $set: { "devices.$.deviceRegistrationStatus": "pending" } },
+        );
+
+        await assert.rejects(
+          callMethod(
+            "devices.setPrimary",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-secondary",
+            },
+          ),
+          /device-not-approved/,
+        );
+      });
+
+      it("moves the primary flag atomically to the target device", async function () {
+        await callMethod(
+          "devices.setPrimary",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-secondary",
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const primaries = doc.devices.filter((d) => d.isPrimary);
+        assert.strictEqual(primaries.length, 1);
+        assert.strictEqual(primaries[0].deviceUUID, "uuid-secondary");
+      });
+    });
+
+    describe("devices.revoke", function () {
+      it("rejects an invalid step-up proof", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.revoke",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-secondary",
+              actorDeviceUUID: "uuid-primary",
+              reAuth: { biometricSecret: "wrong-secret" },
+            },
+          ),
+          /reauth-failed/,
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        assert.strictEqual(doc.devices.length, 2);
+      });
+
+      it("removes the device and promotes a new primary when needed", async function () {
+        await callMethod(
+          "devices.revoke",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-primary",
+            actorDeviceUUID: "uuid-secondary",
+            reAuth: { biometricSecret: BIO_SECRET },
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        assert.strictEqual(doc.devices.length, 1);
+        assert.strictEqual(doc.devices[0].deviceUUID, "uuid-secondary");
+        assert.strictEqual(doc.devices[0].isPrimary, true);
+
+        const audit = await DeviceAuditLog.findOneAsync({
+          userId: USER_A,
+          action: "revoke",
+        });
+        assert.ok(audit, "revocation should be audit-logged");
+      });
+
+      it("deregisters the whole account when the last device is removed", async function () {
+        const userId = await Meteor.users.insertAsync({
+          username: "lastdevice",
+          emails: [{ address: "last@example.com", verified: false }],
+        });
+        await DeviceDetails.insertAsync({
+          userId,
+          username: "lastdevice",
+          email: "last@example.com",
+          devices: [makeDevice({ biometricSecret: "last-bio" })],
+          createdAt: new Date(),
+          lastUpdated: new Date(),
+        });
+
+        const result = await callMethod(
+          "devices.revoke",
+          { userId },
+          {
+            deviceUUID: "uuid-primary",
+            actorDeviceUUID: "uuid-primary",
+            reAuth: { biometricSecret: "last-bio" },
+          },
+        );
+
+        assert.strictEqual(result.accountRemoved, true);
+        assert.strictEqual(
+          await Meteor.users.find({ _id: userId }).countAsync(),
+          0,
+        );
+        assert.strictEqual(
+          await DeviceDetails.find({ userId }).countAsync(),
+          0,
+        );
+      });
+    });
+
+    describe("devices.approvePending", function () {
+      beforeEach(async function () {
+        await DeviceDetails.updateAsync(
+          { userId: USER_A, "devices.deviceUUID": "uuid-secondary" },
+          { $set: { "devices.$.deviceRegistrationStatus": "pending" } },
+        );
+      });
+
+      it("rejects when the acting device is not approved", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.approvePending",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-primary",
+              actorDeviceUUID: "uuid-secondary", // pending device acting
+              approve: true,
+              reAuth: { biometricSecret: BIO_SECRET },
+            },
+          ),
+          /device-not-approved|invalid-status/,
+        );
+      });
+
+      it("approves a pending device from an approved device", async function () {
+        await callMethod(
+          "devices.approvePending",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-secondary",
+            actorDeviceUUID: "uuid-primary",
+            approve: true,
+            reAuth: { biometricSecret: BIO_SECRET },
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find(
+          (d) => d.deviceUUID === "uuid-secondary",
+        );
+        assert.strictEqual(device.deviceRegistrationStatus, "approved");
+      });
+
+      it("removes a pending device on rejection", async function () {
+        await callMethod(
+          "devices.approvePending",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-secondary",
+            actorDeviceUUID: "uuid-primary",
+            approve: false,
+            reAuth: { biometricSecret: BIO_SECRET },
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        assert.strictEqual(doc.devices.length, 1);
+        assert.strictEqual(doc.devices[0].deviceUUID, "uuid-primary");
+      });
+    });
+
+    describe("publications", function () {
+      it("deviceDetails.byUser returns nothing for another user's data", function () {
+        const handler = Meteor.server.publish_handlers["deviceDetails.byUser"];
+        const readySentinel = Symbol("ready");
+        const result = handler.call(
+          { userId: USER_B, ready: () => readySentinel },
+          USER_A,
+        );
+        assert.strictEqual(result, readySentinel);
+      });
+
+      it("deviceDetails.byUser returns nothing when unauthenticated", function () {
+        const handler = Meteor.server.publish_handlers["deviceDetails.byUser"];
+        const readySentinel = Symbol("ready");
+        const result = handler.call(
+          { userId: null, ready: () => readySentinel },
+          USER_A,
+        );
+        assert.strictEqual(result, readySentinel);
+      });
+
+      it("never publishes biometric secrets or FCM tokens", async function () {
+        const handler = Meteor.server.publish_handlers["deviceDetails.byUser"];
+        const cursor = handler.call(
+          { userId: USER_A, ready: () => {} },
+          USER_A,
+        );
+        const docs = await cursor.fetchAsync();
+        assert.ok(docs.length > 0, "expected the user's own document");
+        docs.forEach((doc) => {
+          doc.devices.forEach((device) => {
+            assert.strictEqual(device.biometricSecret, undefined);
+            assert.strictEqual(device.fcmToken, undefined);
+            // Whitelisted fields still come through.
+            assert.ok(device.deviceUUID);
+          });
+        });
+      });
+    });
+
+    describe("internal-only methods", function () {
+      it("users.removeCompletely cannot be called from a client connection", async function () {
+        // server/main.js (where the method lives) is only loaded in full-app
+        // test mode; skip in the unit-test build.
+        if (!Meteor.server.method_handlers["users.removeCompletely"]) {
+          this.skip();
+          return;
+        }
+
+        await assert.rejects(
+          callMethod(
+            "users.removeCompletely",
+            { userId: USER_A, connection: { id: "fake-client-connection" } },
+            USER_A,
+          ),
+          /not-authorized/,
+        );
+      });
+
+      it("FCM token lookups are no longer exposed as Meteor methods", function () {
+        [
+          "deviceDetails",
+          "deviceDetails.updateToken",
+          "deviceDetails.getFCMTokenByUsername",
+          "deviceDetails.getApprovedFCMTokensByUsername",
+          "deviceDetails.getApprovedFCMTokensByUserId",
+          "deviceDetails.getFCMTokenByUserId",
+          "deviceDetails.getFCMTokenByDeviceId",
+          "deviceDetails.getByAppId",
+          "deviceDetails.getByUserId",
+        ].forEach((name) => {
+          assert.strictEqual(
+            Meteor.server.method_handlers[name],
+            undefined,
+            `${name} must not be a callable Meteor method`,
+          );
+        });
+      });
+    });
+  });
+}

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -265,6 +265,55 @@ if (Meteor.isServer) {
         assert.ok(audit, "revocation should be audit-logged");
       });
 
+      it("clears all login tokens when a device revokes itself", async function () {
+        const userId = await Meteor.users.insertAsync({
+          username: "selfrevoke",
+          emails: [{ address: "self@example.com", verified: false }],
+          services: {
+            resume: {
+              loginTokens: [
+                { hashedToken: "token-a", when: new Date() },
+                { hashedToken: "token-b", when: new Date() },
+              ],
+            },
+          },
+        });
+        await DeviceDetails.insertAsync({
+          userId,
+          username: "selfrevoke",
+          email: "self@example.com",
+          devices: [
+            makeDevice({ biometricSecret: "self-bio" }),
+            makeDevice({
+              deviceUUID: "uuid-other",
+              appId: "app-other",
+              biometricSecret: "other-bio",
+              isPrimary: false,
+            }),
+          ],
+          createdAt: new Date(),
+          lastUpdated: new Date(),
+        });
+
+        // Actor revokes itself (deviceUUID === actorDeviceUUID) from a
+        // context WITH a connection — the caller's own token must die too.
+        await callMethod(
+          "devices.revoke",
+          { userId, connection: { id: "conn-1" } },
+          {
+            deviceUUID: "uuid-primary",
+            actorDeviceUUID: "uuid-primary",
+            reAuth: { biometricSecret: "self-bio" },
+          },
+        );
+
+        const user = await Meteor.users.findOneAsync(userId);
+        assert.deepStrictEqual(user.services.resume.loginTokens, []);
+
+        await Meteor.users.removeAsync({ _id: userId });
+        await DeviceDetails.removeAsync({ userId });
+      });
+
       it("deregisters the whole account when the last device is removed", async function () {
         const userId = await Meteor.users.insertAsync({
           username: "lastdevice",

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -118,6 +118,54 @@ if (Meteor.isServer) {
       });
     });
 
+    describe("devices.updateInfo", function () {
+      it("updates the calling device's model/platform and lastUsed", async function () {
+        await callMethod(
+          "devices.updateInfo",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-primary",
+            deviceModel: "iPhone 17 Pro",
+            devicePlatform: "iOS",
+          },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-primary");
+        assert.strictEqual(device.deviceModel, "iPhone 17 Pro");
+        assert.strictEqual(device.devicePlatform, "iOS");
+        assert.ok(device.lastUsed instanceof Date);
+      });
+
+      it("repairs the primary invariant when no approved device is primary", async function () {
+        await DeviceDetails.updateAsync(
+          { userId: USER_A },
+          { $set: { "devices.$[].isPrimary": false } },
+        );
+
+        await callMethod(
+          "devices.updateInfo",
+          { userId: USER_A },
+          { deviceUUID: "uuid-secondary" },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const primaries = doc.devices.filter((d) => d.isPrimary);
+        assert.strictEqual(primaries.length, 1);
+      });
+
+      it("rejects a device not owned by the caller", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.updateInfo",
+            { userId: USER_B },
+            { deviceUUID: "uuid-primary" },
+          ),
+          /not-found/,
+        );
+      });
+    });
+
     describe("devices.setPrimary", function () {
       it("rejects non-approved devices", async function () {
         await DeviceDetails.updateAsync(

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -118,6 +118,28 @@ if (Meteor.isServer) {
       });
     });
 
+    describe("devices.checkRegistrationByUUID", function () {
+      it("reports a registered device with its status", async function () {
+        const result = await callMethod(
+          "devices.checkRegistrationByUUID",
+          {},
+          "uuid-primary",
+        );
+        assert.strictEqual(result.registered, true);
+        assert.strictEqual(result.status, "approved");
+      });
+
+      it("reports an unknown device as unregistered", async function () {
+        const result = await callMethod(
+          "devices.checkRegistrationByUUID",
+          {},
+          "no-such-uuid",
+        );
+        assert.strictEqual(result.registered, false);
+        assert.strictEqual(result.status, null);
+      });
+    });
+
     describe("devices.updateInfo", function () {
       it("updates the calling device's model/platform and lastUsed", async function () {
         await callMethod(

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -202,10 +202,30 @@ if (Meteor.isServer) {
             {
               deviceUUID: "uuid-secondary",
               actorDeviceUUID: "uuid-primary",
+              reAuth: { biometricSecret: BIO_SECRET },
             },
           ),
           /device-not-approved/,
         );
+      });
+
+      it("rejects an invalid step-up proof", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.setPrimary",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-secondary",
+              actorDeviceUUID: "uuid-primary",
+              reAuth: { biometricSecret: "wrong-secret" },
+            },
+          ),
+          /reauth-failed/,
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const primary = doc.devices.find((d) => d.isPrimary);
+        assert.strictEqual(primary.deviceUUID, "uuid-primary");
       });
 
       it("transfers directly when initiated from the current primary", async function () {
@@ -215,6 +235,7 @@ if (Meteor.isServer) {
           {
             deviceUUID: "uuid-secondary",
             actorDeviceUUID: "uuid-primary",
+            reAuth: { biometricSecret: BIO_SECRET },
           },
         );
 
@@ -256,6 +277,7 @@ if (Meteor.isServer) {
             {
               deviceUUID: "uuid-secondary",
               actorDeviceUUID: "uuid-secondary",
+              reAuth: { biometricSecret: "xfer-bio" },
             },
           ),
           /primary-unreachable/,

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -201,18 +201,20 @@ if (Meteor.isServer) {
             { userId: USER_A },
             {
               deviceUUID: "uuid-secondary",
+              actorDeviceUUID: "uuid-primary",
             },
           ),
           /device-not-approved/,
         );
       });
 
-      it("moves the primary flag atomically to the target device", async function () {
+      it("transfers directly when initiated from the current primary", async function () {
         await callMethod(
           "devices.setPrimary",
           { userId: USER_A },
           {
             deviceUUID: "uuid-secondary",
+            actorDeviceUUID: "uuid-primary",
           },
         );
 
@@ -220,6 +222,51 @@ if (Meteor.isServer) {
         const primaries = doc.devices.filter((d) => d.isPrimary);
         assert.strictEqual(primaries.length, 1);
         assert.strictEqual(primaries[0].deviceUUID, "uuid-secondary");
+      });
+
+      it("requires the current primary's approval when initiated elsewhere", async function () {
+        const userId = await Meteor.users.insertAsync({
+          username: "xferuser",
+          emails: [{ address: "xfer@example.com", verified: false }],
+        });
+        await DeviceDetails.insertAsync({
+          userId,
+          username: "xferuser",
+          email: "xfer@example.com",
+          devices: [
+            makeDevice(),
+            makeDevice({
+              deviceUUID: "uuid-secondary",
+              appId: "app-secondary",
+              biometricSecret: "xfer-bio",
+              isPrimary: false,
+            }),
+          ],
+          createdAt: new Date(),
+          lastUpdated: new Date(),
+        });
+
+        // Initiated from the secondary device → approval push to the primary
+        // is required. Firebase is not initialised in tests, so the push
+        // cannot be delivered and the method must fail closed (no transfer).
+        await assert.rejects(
+          callMethod(
+            "devices.setPrimary",
+            { userId },
+            {
+              deviceUUID: "uuid-secondary",
+              actorDeviceUUID: "uuid-secondary",
+            },
+          ),
+          /primary-unreachable/,
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId });
+        const primary = doc.devices.find((d) => d.isPrimary);
+        assert.strictEqual(primary.deviceUUID, "uuid-primary");
+
+        await Meteor.users.removeAsync({ _id: userId });
+        await DeviceDetails.removeAsync({ userId });
       });
     });
 
@@ -242,20 +289,38 @@ if (Meteor.isServer) {
         assert.strictEqual(doc.devices.length, 2);
       });
 
-      it("removes the device and promotes a new primary when needed", async function () {
+      it("blocks removing the primary device", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.revoke",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-primary",
+              actorDeviceUUID: "uuid-secondary",
+              reAuth: { biometricSecret: BIO_SECRET },
+            },
+          ),
+          /primary-device-protected/,
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        assert.strictEqual(doc.devices.length, 2);
+      });
+
+      it("removes a non-primary device", async function () {
         await callMethod(
           "devices.revoke",
           { userId: USER_A },
           {
-            deviceUUID: "uuid-primary",
-            actorDeviceUUID: "uuid-secondary",
+            deviceUUID: "uuid-secondary",
+            actorDeviceUUID: "uuid-primary",
             reAuth: { biometricSecret: BIO_SECRET },
           },
         );
 
         const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
         assert.strictEqual(doc.devices.length, 1);
-        assert.strictEqual(doc.devices[0].deviceUUID, "uuid-secondary");
+        assert.strictEqual(doc.devices[0].deviceUUID, "uuid-primary");
         assert.strictEqual(doc.devices[0].isPrimary, true);
 
         const audit = await DeviceAuditLog.findOneAsync({
@@ -297,12 +362,13 @@ if (Meteor.isServer) {
 
         // Actor revokes itself (deviceUUID === actorDeviceUUID) from a
         // context WITH a connection — the caller's own token must die too.
+        // Target is a non-primary device (the primary is protected).
         await callMethod(
           "devices.revoke",
           { userId, connection: { id: "conn-1" } },
           {
-            deviceUUID: "uuid-primary",
-            actorDeviceUUID: "uuid-primary",
+            deviceUUID: "uuid-other",
+            actorDeviceUUID: "uuid-other",
             reAuth: { biometricSecret: "self-bio" },
           },
         );
@@ -314,7 +380,7 @@ if (Meteor.isServer) {
         await DeviceDetails.removeAsync({ userId });
       });
 
-      it("deregisters the whole account when the last device is removed", async function () {
+      it("blocks removing the last approved device (account keeps one trusted device)", async function () {
         const userId = await Meteor.users.insertAsync({
           username: "lastdevice",
           emails: [{ address: "last@example.com", verified: false }],
@@ -328,25 +394,26 @@ if (Meteor.isServer) {
           lastUpdated: new Date(),
         });
 
-        const result = await callMethod(
-          "devices.revoke",
-          { userId },
-          {
-            deviceUUID: "uuid-primary",
-            actorDeviceUUID: "uuid-primary",
-            reAuth: { biometricSecret: "last-bio" },
-          },
+        await assert.rejects(
+          callMethod(
+            "devices.revoke",
+            { userId },
+            {
+              deviceUUID: "uuid-primary",
+              actorDeviceUUID: "uuid-primary",
+              reAuth: { biometricSecret: "last-bio" },
+            },
+          ),
+          /primary-device-protected/,
         );
 
-        assert.strictEqual(result.accountRemoved, true);
-        assert.strictEqual(
-          await Meteor.users.find({ _id: userId }).countAsync(),
-          0,
-        );
         assert.strictEqual(
           await DeviceDetails.find({ userId }).countAsync(),
-          0,
+          1,
         );
+
+        await Meteor.users.removeAsync({ _id: userId });
+        await DeviceDetails.removeAsync({ userId });
       });
     });
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,6 +1,7 @@
 import assert from "assert";
 import "./duo.js";
 import "./healthcheck.js";
+import "./deviceManagement.js";
 
 describe("meteor-app", function () {
   it("package.json has correct name", async function () {

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -352,6 +352,9 @@ if (Meteor.isServer) {
   const OWN_DEVICE_FIELDS = {
     userId: 1,
     username: 1,
+    firstName: 1,
+    lastName: 1,
+    email: 1,
     createdAt: 1,
     lastUpdated: 1,
     "devices.deviceUUID": 1,

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -111,355 +111,290 @@ Meteor.methods({
 
     return { success: true };
   },
+});
 
-  /**
-   * Upsert device details
-   * @param {Object} data - Device details data
-   * @returns {String} Generated appId
-   */
-  deviceDetails: async function (data) {
+/**
+ * Register (upsert) a device for a user.
+ *
+ * Server-internal: intentionally NOT exposed as a Meteor method. Device
+ * records carry credentials (biometricSecret, fcmToken), so registration may
+ * only be driven by trusted server flows (users.register), never directly by
+ * a client.
+ *
+ * @param {Object} data - Device details data
+ * @returns {Object} Registration result including generated appId
+ */
+export const registerDeviceDetails = async (data) => {
+  console.log(
+    " ### Log Step 6 : Inside deviceDetails.js and checking all the data received",
+  );
+
+  // Extended check to include all required fields
+  check(
+    data,
+    Match.ObjectIncluding({
+      username: String,
+      biometricSecret: String,
+      userId: String,
+      email: String,
+      deviceUUID: String,
+      fcmToken: String,
+      firstName: String,
+      lastName: String,
+      isFirstDevice: Match.Maybe(Boolean),
+      isSecondaryDevice: Match.Maybe(Boolean),
+      deviceModel: Match.Maybe(String),
+      devicePlatform: Match.Maybe(String),
+      autoApprove: Match.Maybe(Boolean),
+    }),
+  );
+
+  // Generate appId
+  const creationTime = new Date().toISOString();
+  const appId = generateAppId(data.deviceUUID, data.username, creationTime);
+  const deviceRegistrationStatus = data.autoApprove ? "approved" : "pending";
+  console.log(
+    " ### Log Step 6.1 : Inside deviceDetails.js, generating app Id",
+    JSON.stringify({ appId }),
+  );
+  // Check if this is the first device
+  if (data.isFirstDevice) {
+    // First device registration for first time user
     console.log(
-      " ### Log Step 6 : Inside deviceDetails.js and checking all the data received",
+      "### Log Step 6.2 : Inside deviceDetails.js, Create new user document with first device",
     );
 
-    // Extended check to include all required fields
-    check(
-      data,
-      Match.ObjectIncluding({
-        username: String,
-        biometricSecret: String,
-        userId: String,
-        email: String,
-        deviceUUID: String,
-        fcmToken: String,
-        firstName: String,
-        lastName: String,
-        isFirstDevice: Match.Maybe(Boolean),
-        isSecondaryDevice: Match.Maybe(Boolean),
-        deviceModel: Match.Maybe(String),
-        devicePlatform: Match.Maybe(String),
-        autoApprove: Match.Maybe(Boolean),
-      }),
-    );
+    await DeviceDetails.insertAsync({
+      userId: data.userId,
+      email: data.email,
+      username: data.username,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      devices: [
+        {
+          deviceUUID: data.deviceUUID,
+          appId: appId,
+          biometricSecret: data.biometricSecret,
+          fcmToken: data.fcmToken,
+          deviceModel: data.deviceModel || "Unknown",
+          devicePlatform: data.devicePlatform || "Unknown",
+          isFirstDevice: true,
+          isPrimary: true,
+          isSecondaryDevice: false,
+          deviceRegistrationStatus,
+          lastUpdated: new Date(),
+        },
+      ],
+      createdAt: new Date(),
+      lastUpdated: new Date(),
+    });
 
-    // Generate appId
-    const creationTime = new Date().toISOString();
-    const appId = generateAppId(data.deviceUUID, data.username, creationTime);
-    const deviceRegistrationStatus = data.autoApprove ? "approved" : "pending";
+    return {
+      appId,
+      isRequireAdminApproval: !data.autoApprove,
+    };
+  } else {
+    // Not the first device, set isSecondaryDevice = true
+
+    // Get the existing details against the user
+    const existingDevices = await DeviceDetails.findOneAsync({
+      userId: data.userId,
+    });
     console.log(
-      " ### Log Step 6.1 : Inside deviceDetails.js, generating app Id",
-      JSON.stringify({ appId }),
+      `### Log Step 6.2 : Inside deviceDetails.js, fetching existing device details:`,
+      existingDevices,
     );
-    // Check if this is the first device
-    if (data.isFirstDevice) {
-      // First device registration for first time user
-      console.log(
-        "### Log Step 6.2 : Inside deviceDetails.js, Create new user document with first device",
+
+    if (!existingDevices) {
+      // Handle case where user doesn't exist but isFirstDevice is false
+      console.log("### Warning: User not found but isFirstDevice is false");
+      throw new Meteor.Error(
+        "user-not-found",
+        "User not found but isFirstDevice is false",
       );
+    }
 
-      await DeviceDetails.insertAsync({
-        userId: data.userId,
-        email: data.email,
-        username: data.username,
-        firstName: data.firstName,
-        lastName: data.lastName,
-        devices: [
-          {
-            deviceUUID: data.deviceUUID,
-            appId: appId,
-            biometricSecret: data.biometricSecret,
-            fcmToken: data.fcmToken,
-            deviceModel: data.deviceModel || "Unknown",
-            devicePlatform: data.devicePlatform || "Unknown",
-            isFirstDevice: true,
-            isPrimary: true,
-            isSecondaryDevice: false,
-            deviceRegistrationStatus,
+    const existingDeviceIndex = existingDevices.devices.findIndex(
+      (device) => device.deviceUUID === data.deviceUUID,
+    );
+
+    if (existingDeviceIndex !== -1) {
+      // Update existing device
+      console.log(
+        `### Log Step 6.3 : Inside deviceDetails.js, Existing device details found and updating it, existingDeviceIndex: ${existingDeviceIndex}`,
+      );
+      await DeviceDetails.updateAsync(
+        { userId: data.userId },
+        {
+          $set: {
+            email: data.email,
+            username: data.username,
+            firstName: data.firstName,
+            lastName: data.lastName,
             lastUpdated: new Date(),
+            [`devices.${existingDeviceIndex}.deviceUUID`]: data.deviceUUID,
+            [`devices.${existingDeviceIndex}.appId`]:
+              existingDevices.devices[existingDeviceIndex].appId,
+            [`devices.${existingDeviceIndex}.biometricSecret`]:
+              data.biometricSecret,
+            [`devices.${existingDeviceIndex}.fcmToken`]: data.fcmToken,
+            [`devices.${existingDeviceIndex}.deviceModel`]:
+              data.deviceModel || "Unknown",
+            [`devices.${existingDeviceIndex}.devicePlatform`]:
+              data.devicePlatform || "Unknown",
+            [`devices.${existingDeviceIndex}.deviceRegistrationStatus`]:
+              deviceRegistrationStatus,
+            [`devices.${existingDeviceIndex}.isFirstDevice`]: false,
+            [`devices.${existingDeviceIndex}.isPrimary`]: false,
+            [`devices.${existingDeviceIndex}.isSecondaryDevice`]: true,
+            [`devices.${existingDeviceIndex}.lastUpdated`]: new Date(),
           },
-        ],
-        createdAt: new Date(),
-        lastUpdated: new Date(),
-      });
-
+        },
+      );
       return {
-        appId,
-        isRequireAdminApproval: !data.autoApprove,
+        appId: existingDevices.devices[existingDeviceIndex].appId,
+        isRequireSecondaryDeviceApproval: !data.autoApprove,
       };
     } else {
-      // Not the first device, set isSecondaryDevice = true
-
-      // Get the existing details against the user
-      const existingDevices = await DeviceDetails.findOneAsync({
-        userId: data.userId,
-      });
+      // Add new device to existing user document
       console.log(
-        `### Log Step 6.2 : Inside deviceDetails.js, fetching existing device details:`,
-        existingDevices,
+        "### Log Step 6.3 : Inside deviceDetails.js, Existing device details not found thus creating a new device details against the existing user",
       );
-
-      if (!existingDevices) {
-        // Handle case where user doesn't exist but isFirstDevice is false
-        console.log("### Warning: User not found but isFirstDevice is false");
-        throw new Meteor.Error(
-          "user-not-found",
-          "User not found but isFirstDevice is false",
-        );
-      }
-
-      const existingDeviceIndex = existingDevices.devices.findIndex(
-        (device) => device.deviceUUID === data.deviceUUID,
-      );
-
-      if (existingDeviceIndex !== -1) {
-        // Update existing device
-        console.log(
-          `### Log Step 6.3 : Inside deviceDetails.js, Existing device details found and updating it, existingDeviceIndex: ${existingDeviceIndex}`,
-        );
-        await DeviceDetails.updateAsync(
-          { userId: data.userId },
-          {
-            $set: {
-              email: data.email,
-              username: data.username,
-              firstName: data.firstName,
-              lastName: data.lastName,
-              lastUpdated: new Date(),
-              [`devices.${existingDeviceIndex}.deviceUUID`]: data.deviceUUID,
-              [`devices.${existingDeviceIndex}.appId`]:
-                existingDevices.devices[existingDeviceIndex].appId,
-              [`devices.${existingDeviceIndex}.biometricSecret`]:
-                data.biometricSecret,
-              [`devices.${existingDeviceIndex}.fcmToken`]: data.fcmToken,
-              [`devices.${existingDeviceIndex}.deviceModel`]:
-                data.deviceModel || "Unknown",
-              [`devices.${existingDeviceIndex}.devicePlatform`]:
-                data.devicePlatform || "Unknown",
-              [`devices.${existingDeviceIndex}.deviceRegistrationStatus`]:
-                deviceRegistrationStatus,
-              [`devices.${existingDeviceIndex}.isFirstDevice`]: false,
-              [`devices.${existingDeviceIndex}.isPrimary`]: false,
-              [`devices.${existingDeviceIndex}.isSecondaryDevice`]: true,
-              [`devices.${existingDeviceIndex}.lastUpdated`]: new Date(),
-            },
-          },
-        );
-        return {
-          appId: existingDevices.devices[existingDeviceIndex].appId,
-          isRequireSecondaryDeviceApproval: !data.autoApprove,
-        };
-      } else {
-        // Add new device to existing user document
-        console.log(
-          "### Log Step 6.3 : Inside deviceDetails.js, Existing device details not found thus creating a new device details against the existing user",
-        );
-        await DeviceDetails.updateAsync(
-          { userId: data.userId },
-          {
-            $push: {
-              devices: {
-                deviceUUID: data.deviceUUID,
-                appId: appId,
-                biometricSecret: data.biometricSecret,
-                fcmToken: data.fcmToken,
-                deviceModel: data.deviceModel || "Unknown",
-                devicePlatform: data.devicePlatform || "Unknown",
-                deviceRegistrationStatus,
-                isFirstDevice: false,
-                isPrimary: false,
-                isSecondaryDevice: true,
-                lastUpdated: new Date(),
-              },
-            },
-            $set: {
-              email: data.email,
-              username: data.username,
-              firstName: data.firstName,
-              lastName: data.lastName,
+      await DeviceDetails.updateAsync(
+        { userId: data.userId },
+        {
+          $push: {
+            devices: {
+              deviceUUID: data.deviceUUID,
+              appId: appId,
+              biometricSecret: data.biometricSecret,
+              fcmToken: data.fcmToken,
+              deviceModel: data.deviceModel || "Unknown",
+              devicePlatform: data.devicePlatform || "Unknown",
+              deviceRegistrationStatus,
+              isFirstDevice: false,
+              isPrimary: false,
+              isSecondaryDevice: true,
               lastUpdated: new Date(),
             },
           },
-        );
-        return {
-          appId,
-          isRequireSecondaryDeviceApproval: !data.autoApprove,
-        };
-      }
+          $set: {
+            email: data.email,
+            username: data.username,
+            firstName: data.firstName,
+            lastName: data.lastName,
+            lastUpdated: new Date(),
+          },
+        },
+      );
+      return {
+        appId,
+        isRequireSecondaryDeviceApproval: !data.autoApprove,
+      };
     }
-  },
+  }
+};
 
-  /**
-   * Update FCM token for a device
-   * @param {String} userId - User ID
-   * @param {String} deviceUUID - Device unique identifier
-   * @param {String} fcmToken - Firebase Cloud Messaging token
-   * @returns {Object} Update result
-   */
-  "deviceDetails.updateToken": async function (userId, deviceUUID, fcmToken) {
+/**
+ * Get all FCM tokens registered for a username.
+ *
+ * Server-internal: FCM tokens allow sending pushes to a user's devices and
+ * must never be readable from the client.
+ *
+ * @param {String} username - Username
+ * @returns {Array} Array of FCM tokens
+ */
+export const getFCMTokensByUsername = async (username) => {
+  check(username, String);
+
+  const userDoc = await DeviceDetails.findOneAsync({ username });
+  if (!userDoc) {
+    throw new Meteor.Error(
+      "invalid-username",
+      "No device found with this Username",
+    );
+  }
+
+  return userDoc.devices.map((device) => device.fcmToken);
+};
+
+/**
+ * Get FCM tokens from approved devices only, by userId.
+ *
+ * Server-internal: see getFCMTokensByUsername.
+ *
+ * @param {String} userId - User ID
+ * @returns {Array} Array of FCM tokens from approved devices
+ */
+export const getApprovedFCMTokensByUserId = async (userId) => {
+  check(userId, String);
+
+  const userDoc = await DeviceDetails.findOneAsync({ userId });
+  if (!userDoc) {
+    throw new Meteor.Error(
+      "invalid-username",
+      "No device found with this UserId",
+    );
+  }
+
+  return userDoc.devices
+    .filter((device) => device.deviceRegistrationStatus === "approved")
+    .map((device) => device.fcmToken);
+};
+
+// Publish device details.
+//
+// SECURITY: device credentials (biometricSecret, fcmToken) are never
+// published to any client. Both publications use explicit inclusion
+// projections so newly added sensitive fields can't leak by default.
+if (Meteor.isServer) {
+  // Fields a signed-in user may see about their OWN devices.
+  const OWN_DEVICE_FIELDS = {
+    userId: 1,
+    username: 1,
+    createdAt: 1,
+    lastUpdated: 1,
+    "devices.deviceUUID": 1,
+    "devices.appId": 1,
+    "devices.deviceModel": 1,
+    "devices.devicePlatform": 1,
+    "devices.deviceRegistrationStatus": 1,
+    "devices.isPrimary": 1,
+    "devices.isFirstDevice": 1,
+    "devices.isSecondaryDevice": 1,
+    "devices.customName": 1,
+    "devices.lastUsed": 1,
+    "devices.lastUpdated": 1,
+  };
+
+  Meteor.publish("deviceDetails.byUser", function (userId) {
     check(userId, String);
-    check(deviceUUID, String);
-    check(fcmToken, String);
 
-    return DeviceDetails.updateAsync(
+    // A user may only subscribe to their own device list.
+    if (!this.userId || this.userId !== userId) {
+      return this.ready();
+    }
+
+    return DeviceDetails.find(
+      { userId: this.userId },
+      { fields: OWN_DEVICE_FIELDS },
+    );
+  });
+
+  // Pre-login registration check (used before a session exists). Exposes only
+  // whether the device is registered and its status — no user identifiers,
+  // tokens, or secrets.
+  Meteor.publish("deviceDetails.byDevice", function (deviceUUID) {
+    check(deviceUUID, String);
+
+    return DeviceDetails.find(
+      { "devices.deviceUUID": deviceUUID },
       {
-        userId,
-        "devices.deviceUUID": deviceUUID,
-      },
-      {
-        $set: {
-          "devices.$.fcmToken": fcmToken,
-          "devices.$.lastUpdated": new Date(),
-          lastUpdated: new Date(),
+        fields: {
+          "devices.deviceUUID": 1,
+          "devices.deviceRegistrationStatus": 1,
         },
       },
     );
-  },
-
-  /**
-   * Get all FCM tokens by username
-   * @param {String} username - Username
-   * @returns {Array} Array of FCM tokens
-   */
-  "deviceDetails.getFCMTokenByUsername": async function (username) {
-    check(username, String);
-
-    const userDoc = await DeviceDetails.findOneAsync({ username });
-    if (!userDoc) {
-      throw new Meteor.Error(
-        "invalid-username",
-        "No device found with this Username",
-      );
-    }
-
-    // Return array of FCM tokens from all devices
-    return userDoc.devices.map((device) => device.fcmToken);
-  },
-
-  /**
-   * Get FCM tokens only from approved devices by username
-   * @param {String} username - Username
-   * @returns {Array} Array of FCM tokens from approved devices
-   */
-  "deviceDetails.getApprovedFCMTokensByUsername": async function (username) {
-    check(username, String);
-
-    const userDoc = await DeviceDetails.findOneAsync({ username });
-    if (!userDoc) {
-      throw new Meteor.Error(
-        "invalid-username",
-        "No device found with this Username",
-      );
-    }
-
-    // Filter to only approved devices and return their FCM tokens
-    const approvedDevices = userDoc.devices.filter(
-      (device) => device.deviceRegistrationStatus === "approved",
-    );
-
-    return approvedDevices.map((device) => device.fcmToken);
-  },
-
-  /**
-   * Get FCM tokens only from approved devices by userId
-   * @param {String} userId - User ID
-   * @returns {Array} Array of FCM tokens from approved devices
-   */
-  "deviceDetails.getApprovedFCMTokensByUserId": async function (userId) {
-    check(userId, String);
-
-    const userDoc = await DeviceDetails.findOneAsync({ userId });
-    if (!userDoc) {
-      throw new Meteor.Error(
-        "invalid-username",
-        "No device found with this UserId",
-      );
-    }
-
-    // Filter to only approved devices and return their FCM tokens
-    const approvedDevices = userDoc.devices.filter(
-      (device) => device.deviceRegistrationStatus === "approved",
-    );
-
-    return approvedDevices.map((device) => device.fcmToken);
-  },
-
-  /**
-   * Get all FCM tokens by username
-   * @param {String} userId - User ID
-   * @returns {Array} Array of FCM tokens
-   */
-  "deviceDetails.getFCMTokenByUserId": async function (userId) {
-    check(userId, String);
-
-    const userDoc = await DeviceDetails.findOneAsync({ userId });
-    if (!userDoc) {
-      throw new Meteor.Error(
-        "invalid-username",
-        "No device found with this UserId",
-      );
-    }
-
-    // Return array of FCM tokens from all devices
-    return userDoc.devices.map((device) => device.fcmToken);
-  },
-
-  /**
-   * Get FCM token by device UUID
-   * @param {String} deviceUUID - Device unique identifier
-   * @returns {String} FCM token
-   */
-  "deviceDetails.getFCMTokenByDeviceId": async function (deviceUUID) {
-    check(deviceUUID, String);
-
-    const userDoc = await DeviceDetails.findOneAsync({
-      "devices.deviceUUID": deviceUUID,
-    });
-    if (!userDoc) {
-      throw new Meteor.Error(
-        "invalid-device-id",
-        "No device found with this Device ID",
-      );
-    }
-
-    const device = userDoc.devices.find((d) => d.deviceUUID === deviceUUID);
-    return device.fcmToken;
-  },
-
-  /**
-   * Get device details by App ID
-   * @param {String} appId - App identifier
-   * @returns {Object} Device details
-   */
-  "deviceDetails.getByAppId": async function (appId) {
-    check(appId, String);
-    const userDoc = await DeviceDetails.findOneAsync({
-      "devices.appId": appId,
-    });
-    if (!userDoc) return null;
-    return userDoc.devices.find((d) => d.appId === appId);
-  },
-
-  /**
-   * Get all devices by user ID
-   * @param {String} userId - User ID
-   * @returns {Array} List of device details
-   */
-  "deviceDetails.getByUserId": async function (userId) {
-    check(userId, String);
-    const userDoc = await DeviceDetails.findOneAsync({ userId });
-    return userDoc ? userDoc.devices : [];
-  },
-});
-
-// Publish device details
-if (Meteor.isServer) {
-  Meteor.publish("deviceDetails.byUser", function (userId) {
-    check(userId, String);
-    return DeviceDetails.find({ userId });
-  });
-
-  Meteor.publish("deviceDetails.byDevice", function (deviceUUID) {
-    check(deviceUUID, String);
-    return DeviceDetails.find({ "devices.deviceUUID": deviceUUID });
   });
 }

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -200,9 +200,10 @@ export const registerDeviceDetails = async (data) => {
     const existingDevices = await DeviceDetails.findOneAsync({
       userId: data.userId,
     });
+    // Log only non-sensitive metadata — the document contains credentials
+    // (biometricSecret, fcmToken) that must never reach logs.
     console.log(
-      `### Log Step 6.2 : Inside deviceDetails.js, fetching existing device details:`,
-      existingDevices,
+      `### Log Step 6.2 : Inside deviceDetails.js, fetching existing device details: found=${!!existingDevices}, deviceCount=${existingDevices?.devices?.length ?? 0}`,
     );
 
     if (!existingDevices) {

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -223,6 +223,7 @@ export const registerDeviceDetails = async (data) => {
       console.log(
         `### Log Step 6.3 : Inside deviceDetails.js, Existing device details found and updating it, existingDeviceIndex: ${existingDeviceIndex}`,
       );
+      const existingDevice = existingDevices.devices[existingDeviceIndex];
       await DeviceDetails.updateAsync(
         { userId: data.userId },
         {
@@ -233,8 +234,7 @@ export const registerDeviceDetails = async (data) => {
             lastName: data.lastName,
             lastUpdated: new Date(),
             [`devices.${existingDeviceIndex}.deviceUUID`]: data.deviceUUID,
-            [`devices.${existingDeviceIndex}.appId`]:
-              existingDevices.devices[existingDeviceIndex].appId,
+            [`devices.${existingDeviceIndex}.appId`]: existingDevice.appId,
             [`devices.${existingDeviceIndex}.biometricSecret`]:
               data.biometricSecret,
             [`devices.${existingDeviceIndex}.fcmToken`]: data.fcmToken,
@@ -244,9 +244,15 @@ export const registerDeviceDetails = async (data) => {
               data.devicePlatform || "Unknown",
             [`devices.${existingDeviceIndex}.deviceRegistrationStatus`]:
               deviceRegistrationStatus,
-            [`devices.${existingDeviceIndex}.isFirstDevice`]: false,
-            [`devices.${existingDeviceIndex}.isPrimary`]: false,
-            [`devices.${existingDeviceIndex}.isSecondaryDevice`]: true,
+            // Preserve the device's standing — re-registering the same device
+            // (e.g. app reinstall) must not strip its first/primary flags,
+            // otherwise the account is left with no primary device.
+            [`devices.${existingDeviceIndex}.isFirstDevice`]:
+              existingDevice.isFirstDevice ?? false,
+            [`devices.${existingDeviceIndex}.isPrimary`]:
+              existingDevice.isPrimary ?? false,
+            [`devices.${existingDeviceIndex}.isSecondaryDevice`]:
+              existingDevice.isSecondaryDevice ?? true,
             [`devices.${existingDeviceIndex}.lastUpdated`]: new Date(),
           },
         },

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -390,20 +390,11 @@ if (Meteor.isServer) {
     );
   });
 
-  // Pre-login registration check (used before a session exists). Exposes only
-  // whether the device is registered and its status — no user identifiers,
-  // tokens, or secrets.
-  Meteor.publish("deviceDetails.byDevice", function (deviceUUID) {
-    check(deviceUUID, String);
-
-    return DeviceDetails.find(
-      { "devices.deviceUUID": deviceUUID },
-      {
-        fields: {
-          "devices.deviceUUID": 1,
-          "devices.deviceRegistrationStatus": 1,
-        },
-      },
-    );
-  });
+  // NOTE: there is intentionally NO second publication over this collection.
+  // The old `deviceDetails.byDevice` publication published a different
+  // projection of the same top-level `devices` field, and Meteor's DDP merge
+  // box (which tracks top-level fields only) let it clobber the full
+  // projection above — devices rendered as "Unknown" with no primary flag.
+  // The pre-login registration check is now the `devices.checkRegistrationByUUID`
+  // method (server/deviceManagement.js).
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/ba783077-fdbe-4e82-9e8d-e9514bd3de15



Closes #424

## Summary

Adds a self-service **My Devices** screen so a signed-in user can manage the devices registered to their own 2FA account, and closes several pre-existing security gaps on the shared device-data paths.

Since any approved device can approve/reject authentication requests and each device holds its own biometric secret + FCM token, a lost/compromised device previously retained approval power indefinitely (only an admin could remove it). This feature gives users direct, safe control over their devices.

## Feature — "My Devices" (`/settings/devices`, protected, mobile-only)

- **List devices** — platform, model, registration status, primary badge, "This device" marker, and last-used time.
- **Rename** a device (custom label).
- **Set primary** device — a trust transfer that requires the **current primary's approval** (actionable push) unless initiated from the primary itself.
- **Revoke** a device — the **primary (or only approved) device is protected** and can never be removed; transfer the primary role first.
- **Approve / reject pending** secondary devices from an already-approved device.
- Entry point added to the dashboard header overflow (⋮) menu.

### Security model

- **Step-up re-authentication** for every destructive/trust-changing action (revoke, approve/reject pending): an OS biometric prompt (device-bound secret) or the account PIN, verified server-side per call with a constant-time comparison. Stateless — no token collection, so it is multi-instance safe.
- Every method requires `this.userId` and operates **only on the caller's own** `DeviceDetails` document.
- **Revoke** removes the device record (incl. `biometricSecret` + `fcmToken`), invalidates the account's other sessions, and pushes a silent `device_revoked` notice that makes the revoked device wipe local credentials and sign out. Remaining approved devices get a courtesy notice.
- **Primary device protection** (requirement updated during review — supersedes the original "last device deregisters the account" criterion): the primary / only approved device **cannot be removed**, so the account always keeps one trusted device. Enforced server-side (`primary-device-protected`) and in the UI. A lost primary requires admin revocation (`/api/admin/devices/revoke`).
- **Primary transfers need the incumbent's consent**: `devices.setPrimary` sends an actionable approve/reject push to the current primary (the `notificationId` needed to answer is delivered only in that push) and fails closed on rejection, timeout, or unreachable device. Every actual change is announced to all approved devices after a short delay so the notice lands as a visible OS banner (foreground receivers get an in-app toast).
- `devices.lastUsed` is tracked on biometric login and notification responses.
- Insert-only `deviceAuditLog` records every rename / setPrimary / revoke / approval.

## Security hardening (pre-existing gaps on the same data paths)

- `deviceDetails.byUser` publication had **no auth check** — now owner-only with an inclusion projection; `biometricSecret` / `fcmToken` are never published. The pre-login check is the `devices.checkRegistrationByUUID` method (returns only `{ registered, status }`); the old `byDevice` publication was removed to avoid DDP merge-box conflicts.
- FCM-token / device-lookup Meteor methods and the `deviceDetails` registration method were **client-callable** (anyone could fetch any user's push tokens or register an auto-approved device on any account). Converted to server-internal functions; dead methods removed.
- `devices.respondToSecondaryApproval` now requires the authenticated owner.
- `users.removeCompletely` is now server-internal only.
- **DDP rate limiting** (10/min per connection) on `users.loginWithBiometric`, `users.register`, and the new device-management methods.

## Files

| Change | File |
|---|---|
| New — My Devices page + step-up confirm modal | `client/mobile/src/ui/DeviceManagementPage.jsx` |
| New — device management methods, step-up auth, audit log, rate limiting | `server/deviceManagement.js` |
| New — server + publication tests | `tests/deviceManagement.js` |
| Hardened publications; internal registration/token functions | `utils/api/deviceDetails.js` |
| Internal-only `removeCompletely`, `lastUsed` tracking, owner check on secondary approval, wiring | `server/main.js` |
| `device_revoked` push handling (wipe + logout) | `client/mobile/push-notifications.js` |
| Route `/settings/devices` | `client/mobile/src/ui/components/AppRoutes.jsx` |
| "My devices" menu entry | `client/mobile/src/ui/components/DashboardHeader.jsx` |
| `ddp-rate-limiter` package | `.meteor/packages` |
| Test harness include | `tests/main.js` |

## Testing

- `tests/deviceManagement.js`: ownership enforcement across every method, step-up proof rejection, primary-protection on revoke (incl. last device), direct vs. approval-gated primary transfer (fails closed when the primary is unreachable), self-revoke session invalidation, publication projection (no secret leak, no cross-user data), and that internal methods are no longer client-callable.
- Full suite: **101 passing / 1 skipped**. The remaining failures are **pre-existing on `development`** (verified via a baseline run) and unrelated to this change.

## Manual verification (needs real hardware)

No new Cordova plugins, so no native rebuild is required. Before release, verify the two-device flow on devices:
1. Register a 2nd device → approve it from the 1st via **My Devices**.
2. Revoke the 2nd device → confirm it is signed out, its sessions are dead, and it receives no further 2FA pushes.
3. Revoke the last remaining device → confirm the account is deregistered and re-registration requires admin approval.

