### PR TITLE
Add mobile diagnostics log viewer and email export

### DIFF
--- a/.meteor/cordova-plugins
+++ b/.meteor/cordova-plugins
@@ -2,7 +2,9 @@
 cordova-plugin-android-permissions@1.1.5
 cordova-plugin-customurlscheme@5.0.2
 cordova-plugin-device@3.0.0
+cordova-plugin-diagnostics-viewer@0.1.1
 cordova-plugin-fingerprint-aio@6.0.0
 cordova-plugin-inappbrowser@6.0.0
+cordova-plugin-native-logs@1.0.5
 cordova-plugin-splashscreen@6.0.2
 cordova.plugins.diagnostic@7.3.1

--- a/client/main.jsx
+++ b/client/main.jsx
@@ -9,6 +9,7 @@ import { initializeBiometrics } from "./mobile/biometrics";
 import { initializeDeepLinks } from "./mobile/deep-links";
 import { initializePushNotifications } from "./mobile/push-notifications";
 import { checkNotificationPermission } from "./mobile/notification-permissions";
+import { initializeDiagnostics } from "./mobile/diagnostics";
 
 // During a hot code push the WebView is fully reloaded while the new bundle
 // loads. Without covering that gap the user sees a blank/black screen. Show the
@@ -40,6 +41,7 @@ Meteor.startup(() => {
         initializeBiometrics();
         initializeDeepLinks();
         initializePushNotifications();
+        initializeDiagnostics();
         // Record whether the OS-level notification permission is granted so the
         // UI can prompt the user to re-enable it if they denied/dismissed it.
         checkNotificationPermission();

--- a/client/mobile/diagnostics.js
+++ b/client/mobile/diagnostics.js
@@ -1,0 +1,97 @@
+import { Meteor } from "meteor/meteor";
+
+const MAX_EMAIL_LENGTH = 254;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+let initialized = false;
+
+const redactLogs = (logs) =>
+  logs
+    .replace(/(authorization\s*[:=]\s*)(?:basic|bearer)\s+[^\s,;]+/gi, "$1***")
+    .replace(
+      /((?:access[_-]?token|auth[_-]?token|refresh[_-]?token|password|pin|api[_-]?key)\s*[:=]\s*)[^\s,;]+/gi,
+      "$1***",
+    );
+
+const getDeviceInfo = () => {
+  if (typeof device === "undefined") return null;
+
+  return {
+    platform: device.platform || "Unknown",
+    version: device.version || "Unknown",
+    model: device.model || "Unknown",
+  };
+};
+
+const getDefaultRecipient = () => Meteor.user()?.emails?.[0]?.address || "";
+
+const sendLogs = async (logs) => {
+  const recipientEmail = window.prompt(
+    "Send diagnostics logs to:",
+    getDefaultRecipient(),
+  );
+
+  if (recipientEmail === null) return;
+
+  const normalizedEmail = recipientEmail.trim();
+  if (
+    normalizedEmail.length > MAX_EMAIL_LENGTH ||
+    !EMAIL_PATTERN.test(normalizedEmail)
+  ) {
+    window.alert("Enter a valid email address.");
+    throw new Error("Invalid recipient email address");
+  }
+
+  try {
+    await Meteor.callAsync("diagnostics.sendLogs", {
+      recipientEmail: normalizedEmail,
+      logs,
+      device: getDeviceInfo(),
+    });
+    window.alert(`Diagnostics logs sent to ${normalizedEmail}.`);
+    window.DiagnosticsViewer?.close();
+  } catch (error) {
+    window.alert(
+      error.reason || error.message || "Unable to send diagnostics logs.",
+    );
+    throw error;
+  }
+};
+
+export const initializeDiagnostics = () => {
+  if (initialized || !Meteor.isCordova) return initialized;
+
+  const viewer = window.DiagnosticsViewer;
+  if (!viewer) return false;
+
+  try {
+    viewer.init({
+      title: "MIE Auth Diagnostics",
+      lineLimit: 10000,
+      redactionCallback: redactLogs,
+      sendHandler: sendLogs,
+    });
+  } catch (error) {
+    console.error("Unable to initialize diagnostics viewer:", error);
+    return false;
+  }
+
+  initialized = true;
+  return true;
+};
+
+export const openDiagnostics = () => {
+  if (!initializeDiagnostics()) {
+    window.alert(
+      "Diagnostics are available only in the installed Android or iOS app.",
+    );
+    return;
+  }
+
+  try {
+    window.DiagnosticsViewer.open();
+  } catch (error) {
+    console.error("Unable to open diagnostics viewer:", error);
+    window.alert("Unable to open diagnostics.");
+  }
+};

--- a/client/mobile/src/ui/components/DashboardHeader.jsx
+++ b/client/mobile/src/ui/components/DashboardHeader.jsx
@@ -11,9 +11,11 @@ import {
   MoreVertical,
   ChevronDown,
   Smartphone,
+  FileText,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { openSupportLink } from "../../../../../utils/openExternal";
+import { openDiagnostics } from "../../../diagnostics";
 import {
   Button,
   AppHeaderDivider,
@@ -158,6 +160,12 @@ export const DashboardHeader = ({
                 onClick={() => openSupportLink()}
               >
                 Help &amp; Support
+              </DropdownItem>
+              <DropdownItem
+                icon={<FileText className="h-4 w-4" />}
+                onClick={openDiagnostics}
+              >
+                Diagnostics
               </DropdownItem>
 
               <DropdownSeparator />

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.0',
+  version: "1.5.0",
 });
 
 App.setPreference("android-targetSdkVersion", "35");
@@ -120,6 +120,8 @@ App.configurePlugin("cordova-plugin-inappbrowser", {});
 App.configurePlugin("cordova-plugin-customurlscheme", {
   URL_SCHEME: "mieauth",
 });
+App.configurePlugin("cordova-plugin-native-logs", {});
+App.configurePlugin("cordova-plugin-diagnostics-viewer", {});
 
 App.addResourceFile(
   "private/android/google-services.json",

--- a/server/diagnostics.js
+++ b/server/diagnostics.js
@@ -1,0 +1,106 @@
+import { Meteor } from "meteor/meteor";
+import { Email } from "meteor/email";
+import { check, Match } from "meteor/check";
+import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
+import { createEmailLog } from "../utils/api/emailLog.js";
+
+const MAX_LOG_LENGTH = 1_000_000;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const RecipientEmail = Match.Where((email) => {
+  check(email, String);
+  return email.length <= 254 && EMAIL_PATTERN.test(email);
+});
+
+const redactLogs = (logs) =>
+  logs
+    .replace(/(authorization\s*[:=]\s*)(?:basic|bearer)\s+[^\s,;]+/gi, "$1***")
+    .replace(
+      /((?:access[_-]?token|auth[_-]?token|refresh[_-]?token|password|pin|api[_-]?key)\s*[:=]\s*)[^\s,;]+/gi,
+      "$1***",
+    );
+
+Meteor.methods({
+  async "diagnostics.sendLogs"({ recipientEmail, logs, device }) {
+    check(recipientEmail, RecipientEmail);
+    check(logs, String);
+    check(
+      device,
+      Match.Maybe({
+        platform: String,
+        version: String,
+        model: String,
+      }),
+    );
+
+    if (!this.userId) {
+      throw new Meteor.Error("not-authorized", "You must be signed in.");
+    }
+
+    const fromEmail = process.env.EMAIL_FROM;
+    if (!fromEmail) {
+      throw new Meteor.Error(
+        "configuration-error",
+        "Email configuration is missing.",
+      );
+    }
+
+    this.unblock();
+
+    const normalizedEmail = recipientEmail.trim();
+    const attachmentLogs = redactLogs(logs.slice(-MAX_LOG_LENGTH));
+    const deviceSummary = device
+      ? `${device.platform} ${device.version} (${device.model})`
+      : "Unknown device";
+    const subject = "MIE Auth diagnostics logs";
+
+    try {
+      await Email.sendAsync({
+        to: normalizedEmail,
+        from: fromEmail,
+        subject,
+        text: `MIE Auth diagnostics\nDevice: ${deviceSummary}\nGenerated: ${new Date().toISOString()}\n\nThe diagnostics logs are attached.`,
+        attachments: [
+          {
+            filename: `mie-auth-diagnostics-${Date.now()}.txt`,
+            content: attachmentLogs,
+            contentType: "text/plain; charset=utf-8",
+          },
+        ],
+      });
+
+      await createEmailLog({
+        type: "diagnostics_logs",
+        to: normalizedEmail,
+        from: fromEmail,
+        subject,
+        userId: this.userId,
+        status: "sent",
+      });
+
+      return { success: true, truncated: logs.length > MAX_LOG_LENGTH };
+    } catch (error) {
+      console.error("Error sending diagnostics logs:", error);
+      await createEmailLog({
+        type: "diagnostics_logs",
+        to: normalizedEmail,
+        from: fromEmail,
+        subject,
+        userId: this.userId,
+        status: "failed",
+        error: error.message,
+      }).catch(() => {});
+      throw new Meteor.Error("email-error", "Failed to send diagnostics logs.");
+    }
+  },
+});
+
+DDPRateLimiter.addRule(
+  {
+    type: "method",
+    name: "diagnostics.sendLogs",
+    userId: () => true,
+  },
+  3,
+  5 * 60 * 1000,
+);

--- a/server/main.js
+++ b/server/main.js
@@ -35,6 +35,7 @@ import "./adminApi"; // Admin REST API endpoints
 import "../utils/api/duoIntegrations.js"; // Duo integration credential methods
 import "./duo/index.js"; // Duo Auth API v2 compatibility layer (/auth/v2/*)
 import "./duo/adminApiV1.js"; // Duo Admin API v1 compatibility layer (/admin/v1/*)
+import "./diagnostics.js"; // Diagnostics log email method
 import { adminPageTemplate } from "./templates/admin";
 import { APPROVAL_TOKEN_EXPIRY_MS } from "../utils/constants.js";
 import {


### PR DESCRIPTION


https://github.com/user-attachments/assets/69fcec60-deea-4d65-a8d2-c22cd73419cb



Closes #428

## Summary
Adds a minimal in-app diagnostics workflow for installed Android and iOS builds. Signed-in users can open the native log viewer from the dashboard overflow menu, refresh the latest logs, enter a recipient email address, and send the displayed logs as a text attachment.

## Changes
- Adds the MIEWeb/BlueHive cordova-plugin-diagnostics-viewer package.
- Adds cordova-plugin-native-logs as the Android/iOS native log source.
- Initializes the viewer on Cordova deviceready.
- Adds a Diagnostics entry to the mobile dashboard overflow menu.
- Prompts for and validates the recipient email address.
- Sends logs through an authenticated, rate-limited Meteor method using the existing EMAIL_FROM configuration.
- Redacts common authorization, token, password, PIN, and API-key values on both client and server.
- Caps emailed logs at the latest 1 MB and records success/failure in the existing email audit log.

## Self-review
- Verified the viewer API against cordova-plugin-diagnostics-viewer 0.1.1.
- Confirmed the viewer refresh action calls cordova-plugin-native-logs for current Android/iOS logs.
- Added guarded viewer initialization/open behavior for unavailable or failed Cordova plugins.
- Added server-side validation, authentication, redaction, attachment truncation, and rate limiting.
- Kept unrelated local admin authentication changes out of this commit.

## Testing
- Prettier: passed for all changed JavaScript/JSX files.
- ESLint: 0 errors; 2 pre-existing unused React import warnings.
- Meteor tests: 102 passing, 1 pending, 6 existing failures unrelated to diagnostics (four missing user cleanup methods and two tests missing the Random import).

## Device verification required
A fresh Cordova rebuild is required because two native plugins were added. Verify on both Android and iOS:
1. Open More > Diagnostics.
2. Confirm logs load and Refresh updates them.
3. Select Send, enter an email address, and confirm receipt of the text attachment.