### PR TITLE
fix: prevent false device registration resets

### DIFF
--- a/client/mobile/src/ui/App.jsx
+++ b/client/mobile/src/ui/App.jsx
@@ -60,8 +60,12 @@ const ConnectionError = ({ onRetry }) => {
 };
 
 export const App = () => {
-  const { capturedDeviceUuid, boolRegisteredDevice, isLoading } =
-    useDeviceRegistration();
+  const {
+    capturedDeviceUuid,
+    boolRegisteredDevice,
+    registrationError,
+    isLoading,
+  } = useDeviceRegistration();
   const [showError, setShowError] = useState(false);
   const loadingRef = useRef(isLoading);
 
@@ -81,7 +85,7 @@ export const App = () => {
 
   return (
     <>
-      {showError ? (
+      {showError || registrationError ? (
         <ConnectionError onRetry={handleRetry} />
       ) : isLoading ? (
         <LoadingState />

--- a/client/mobile/src/ui/hooks/useDeviceRegistration.js
+++ b/client/mobile/src/ui/hooks/useDeviceRegistration.js
@@ -6,6 +6,7 @@ import { Tracker } from "meteor/tracker";
 export const useDeviceRegistration = () => {
   const [capturedDeviceUuid, setCapturedDeviceUuid] = useState(null);
   const [boolRegisteredDevice, setBoolRegisteredDevice] = useState(null);
+  const [registrationError, setRegistrationError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -20,20 +21,32 @@ export const useDeviceRegistration = () => {
 
       if (!deviceInfo || !deviceInfo.uuid) {
         setCapturedDeviceUuid(null);
-        setBoolRegisteredDevice(false);
-        setIsLoading(false);
+        setBoolRegisteredDevice(null);
+        setIsLoading(true);
         return;
       }
       setCapturedDeviceUuid(deviceInfo.uuid);
 
       if (deviceInfo.uuid === lastCheckedUuid) return;
       lastCheckedUuid = deviceInfo.uuid;
+      setRegistrationError(null);
+      setIsLoading(true);
 
       Meteor.call(
         "devices.checkRegistrationByUUID",
         deviceInfo.uuid,
         (error, result) => {
-          setBoolRegisteredDevice(!error && !!result?.registered);
+          if (error || typeof result?.registered !== "boolean") {
+            console.error("Unable to check device registration:", error);
+            setRegistrationError(
+              error || new Error("Invalid device registration response"),
+            );
+            setIsLoading(false);
+            return;
+          }
+
+          setRegistrationError(null);
+          setBoolRegisteredDevice(result.registered);
           setIsLoading(false);
         },
       );
@@ -44,5 +57,10 @@ export const useDeviceRegistration = () => {
     };
   }, []);
 
-  return { capturedDeviceUuid, boolRegisteredDevice, isLoading };
+  return {
+    capturedDeviceUuid,
+    boolRegisteredDevice,
+    registrationError,
+    isLoading,
+  };
 };


### PR DESCRIPTION
## Problem
v1.5.2 treats any device-registration lookup error as an unregistered device. Transient network, DDP, server, malformed-response, or rate-limit failures therefore route existing users into onboarding and make registration appear lost.

## Fix
- Keep missing device identity in a loading/indeterminate state
- Treat lookup errors and invalid responses as connection failures
- Route to onboarding only after an explicit successful registered=false response
- Show the existing Connection Issues screen with retry for lookup failures

## Validation
- ESLint: 0 errors; one pre-existing unused React import warning in App.jsx
- Full suite: 102 passing, 1 pending; 6 unrelated pre-existing failures in cleanup/notification tests

## Scope
Only the mobile registration hook and app routing state are changed.