### PR TITLE
hotfix: prevent false device registration resets

### DIFF
--- a/client/mobile/src/ui/App.jsx
+++ b/client/mobile/src/ui/App.jsx
@@ -60,8 +60,12 @@ const ConnectionError = ({ onRetry }) => {
 };
 
 export const App = () => {
-  const { capturedDeviceUuid, boolRegisteredDevice, isLoading } =
-    useDeviceRegistration();
+  const {
+    capturedDeviceUuid,
+    boolRegisteredDevice,
+    registrationError,
+    isLoading,
+  } = useDeviceRegistration();
   const [showError, setShowError] = useState(false);
   const loadingRef = useRef(isLoading);
 
@@ -81,7 +85,7 @@ export const App = () => {
 
   return (
     <>
-      {showError ? (
+      {showError || registrationError ? (
         <ConnectionError onRetry={handleRetry} />
       ) : isLoading ? (
         <LoadingState />

--- a/client/mobile/src/ui/hooks/useDeviceRegistration.js
+++ b/client/mobile/src/ui/hooks/useDeviceRegistration.js
@@ -6,6 +6,7 @@ import { Tracker } from "meteor/tracker";
 export const useDeviceRegistration = () => {
   const [capturedDeviceUuid, setCapturedDeviceUuid] = useState(null);
   const [boolRegisteredDevice, setBoolRegisteredDevice] = useState(null);
+  const [registrationError, setRegistrationError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -20,20 +21,32 @@ export const useDeviceRegistration = () => {
 
       if (!deviceInfo || !deviceInfo.uuid) {
         setCapturedDeviceUuid(null);
-        setBoolRegisteredDevice(false);
-        setIsLoading(false);
+        setBoolRegisteredDevice(null);
+        setIsLoading(true);
         return;
       }
       setCapturedDeviceUuid(deviceInfo.uuid);
 
       if (deviceInfo.uuid === lastCheckedUuid) return;
       lastCheckedUuid = deviceInfo.uuid;
+      setRegistrationError(null);
+      setIsLoading(true);
 
       Meteor.call(
         "devices.checkRegistrationByUUID",
         deviceInfo.uuid,
         (error, result) => {
-          setBoolRegisteredDevice(!error && !!result?.registered);
+          if (error || typeof result?.registered !== "boolean") {
+            console.error("Unable to check device registration:", error);
+            setRegistrationError(
+              error || new Error("Invalid device registration response"),
+            );
+            setIsLoading(false);
+            return;
+          }
+
+          setRegistrationError(null);
+          setBoolRegisteredDevice(result.registered);
           setIsLoading(false);
         },
       );
@@ -44,5 +57,10 @@ export const useDeviceRegistration = () => {
     };
   }, []);
 
-  return { capturedDeviceUuid, boolRegisteredDevice, isLoading };
+  return {
+    capturedDeviceUuid,
+    boolRegisteredDevice,
+    registrationError,
+    isLoading,
+  };
 };

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.2',
+  version: '1.5.3',
 });
 
 App.setPreference("android-targetSdkVersion", "35");

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.1',
+  version: '1.5.2',
 });
 
 App.setPreference("android-targetSdkVersion", "35");

--- a/public/buildInfo.json
+++ b/public/buildInfo.json
@@ -1,6 +1,6 @@
 {
-  "appVersion": "1.5.2",
-  "buildNumber": "56b0c1c",
-  "buildDate": "2026-08-07T12:33:57.127Z",
-  "commitDate": "2026-08-07 12:31:50 +0000"
+  "appVersion": "1.5.3",
+  "buildNumber": "5ad7f3a",
+  "buildDate": "2026-08-07T12:46:13.148Z",
+  "commitDate": "2026-08-07 08:44:13 -0400"
 }

--- a/public/buildInfo.json
+++ b/public/buildInfo.json
@@ -1,6 +1,6 @@
 {
-  "appVersion": "1.5.1",
-  "buildNumber": "d6883ec",
-  "buildDate": "2026-07-31T20:02:40.062Z",
-  "commitDate": "2026-07-31 16:01:24 -0400"
+  "appVersion": "1.5.2",
+  "buildNumber": "18854d4",
+  "buildDate": "2026-08-07T12:31:50.428Z",
+  "commitDate": "2026-08-06 12:12:20 -0400"
 }

--- a/public/buildInfo.json
+++ b/public/buildInfo.json
@@ -1,6 +1,6 @@
 {
   "appVersion": "1.5.2",
-  "buildNumber": "18854d4",
-  "buildDate": "2026-08-07T12:31:50.428Z",
-  "commitDate": "2026-08-06 12:12:20 -0400"
+  "buildNumber": "56b0c1c",
+  "buildDate": "2026-08-07T12:33:57.127Z",
+  "commitDate": "2026-08-07 12:31:50 +0000"
 }


### PR DESCRIPTION
## Production incident
v1.5.2 can interpret a failed device-registration lookup as an unregistered device, routing an existing user into onboarding and making their registration appear lost.

## Hotfix
- Keep missing device identity in an indeterminate loading state
- Treat lookup errors and malformed responses as connection failures
- Show the existing Connection Issues screen with retry
- Route to onboarding only after an explicit successful registered=false response

## Included changes
- Device-registration lookup and routing fix from PR #434
- Automated version/build metadata update to 1.5.3

## Validation
- ESLint: 0 errors; one pre-existing unused React import warning
- Full suite: 102 passing, 1 pending; 6 unrelated existing test failures

## Deployment note
This PR is intentionally not merged. Merge only after review and production release approval.