### PR TITLE
fix: restore web landing page (skip device check on browsers)

### DIFF
--- a/client/mobile/src/ui/hooks/useDeviceRegistration.js
+++ b/client/mobile/src/ui/hooks/useDeviceRegistration.js
@@ -10,6 +10,18 @@ export const useDeviceRegistration = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    // Web browsers have no Cordova device UUID — device registration only
+    // applies to the mobile app. Without this guard the hook waits forever
+    // for device info that never arrives and the web landing page is
+    // replaced by the Connection Issues screen after the loading timeout.
+    if (!Meteor.isCordova) {
+      setCapturedDeviceUuid(null);
+      setBoolRegisteredDevice(false);
+      setRegistrationError(null);
+      setIsLoading(false);
+      return undefined;
+    }
+
     let lastCheckedUuid = null;
 
     // Uses the devices.checkRegistrationByUUID method instead of subscribing


### PR DESCRIPTION
## Problem
The v1.5.3 registration hotfix keeps the app in a loading state while waiting for a Cordova device UUID. Web browsers never provide one, so after the 10s timeout the public website shows the Connection Issues screen instead of the landing page.

## Fix
Skip the device registration check entirely when not running under Cordova. Web visitors get isLoading=false immediately and AppRoutes renders WebLandingPage as before. Mobile behavior is unchanged.

## Impact
- Web: landing page restored immediately
- Mobile registered device: login (unchanged)
- Mobile new device: onboarding (unchanged)
- Mobile lookup failure: Connection Issues with retry (unchanged)

## Deployment note
Server deploy delivers this to installed v1.5.3 apps via hot code push; a follow-up store build (v1.5.4) can bundle it natively.