### PR TITLE
hotfix: restore web landing page (skip device check on browsers)

### DIFF
--- a/client/mobile/src/ui/hooks/useDeviceRegistration.js
+++ b/client/mobile/src/ui/hooks/useDeviceRegistration.js
@@ -10,6 +10,18 @@ export const useDeviceRegistration = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    // Web browsers have no Cordova device UUID — device registration only
+    // applies to the mobile app. Without this guard the hook waits forever
+    // for device info that never arrives and the web landing page is
+    // replaced by the Connection Issues screen after the loading timeout.
+    if (!Meteor.isCordova) {
+      setCapturedDeviceUuid(null);
+      setBoolRegisteredDevice(false);
+      setRegistrationError(null);
+      setIsLoading(false);
+      return undefined;
+    }
+
     let lastCheckedUuid = null;
 
     // Uses the devices.checkRegistrationByUUID method instead of subscribing

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.3',
+  version: '1.5.4',
 });
 
 App.setPreference("android-targetSdkVersion", "35");

--- a/public/buildInfo.json
+++ b/public/buildInfo.json
@@ -1,6 +1,6 @@
 {
-  "appVersion": "1.5.3",
-  "buildNumber": "5ad7f3a",
-  "buildDate": "2026-08-07T12:46:13.148Z",
-  "commitDate": "2026-08-07 08:44:13 -0400"
+  "appVersion": "1.5.4",
+  "buildNumber": "3548120",
+  "buildDate": "2026-08-07T14:09:39.235Z",
+  "commitDate": "2026-08-07 10:08:30 -0400"
 }


### PR DESCRIPTION
## Problem
The v1.5.3 registration hotfix leaves web browsers waiting for a Cordova device UUID that never arrives. After the 10s loading timeout, the public website (mieauth-prod.os.mieweb.org) shows the Connection Issues screen instead of the landing page.

## Fix
Skip the device registration check when not running under Cordova (PR #436, merged to development as dev-v1.5.4). Web visitors immediately render WebLandingPage; mobile behavior is unchanged.

## Impact
- Web: landing page restored
- Mobile registered device: login (unchanged)
- Mobile new device: onboarding (unchanged)
- Mobile lookup failure: Connection Issues with retry (unchanged)

## Deployment note
Server deploy also delivers this to installed v1.5.3 apps via Meteor hot code push — no new store binaries required for the immediate fix.