### PR TITLE
Target Android API 36 in beta builds

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -272,6 +272,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Install Android SDK 36
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: Install Meteor
         run: |
           curl https://install.meteor.com/ | sh
@@ -311,6 +314,30 @@ jobs:
           meteor build ./android-build \
             --platforms android \
             --server=https://mieauth-dev.os.mieweb.org
+
+      - name: Verify AAB targets Android API 36
+        run: |
+          BUNDLETOOL_VERSION="1.18.2"
+          BUNDLETOOL_JAR="${RUNNER_TEMP}/bundletool.jar"
+          UNSIGNED_AAB=$(find android-build -name "*.aab" -type f | head -1)
+          if [ -z "$UNSIGNED_AAB" ]; then
+            echo "ERROR: No AAB file found"
+            exit 1
+          fi
+
+          curl -fsSL \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
+            -o "$BUNDLETOOL_JAR"
+
+          TARGET_SDK=$(java -jar "$BUNDLETOOL_JAR" dump manifest \
+            --bundle="$UNSIGNED_AAB" \
+            --xpath=/manifest/uses-sdk/@android:targetSdkVersion)
+
+          if [ "$TARGET_SDK" != "36" ]; then
+            echo "ERROR: Expected target SDK 36, found ${TARGET_SDK:-unknown}"
+            exit 1
+          fi
+          echo "Verified AAB target SDK: $TARGET_SDK"
 
       - name: Decode Keystore
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > mieauth-release-key.jks

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,11 +5,12 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.4',
+  version: "1.5.4",
 });
 
-App.setPreference("android-targetSdkVersion", "35");
-App.setPreference("android-compileSdkVersion", "35");
+App.setPreference("android-targetSdkVersion", "36");
+App.setPreference("android-compileSdkVersion", "36");
+App.setPreference("android-buildToolsVersion", "36.0.0");
 // Preferences per latest Meteor docs
 // Use the brand color (matches SplashScreenBackgroundColor) instead of black so
 // the WebView background shown during hot code push reloads is not a black flash.


### PR DESCRIPTION
## Summary
- Target and compile against Android API 36.
- Use Android Build Tools 36.0.0.
- Provision Android SDK 36 in the development Android workflow.
- Verify that the generated Beta AAB targets SDK 36 before signing and Play upload.

## Scope
This intentionally updates only the Beta deployment workflow. The production workflow will be updated after the Beta build and Android 16 smoke tests pass.

No shared mieweb/actions changes are required because this Android job invokes meteor build directly.

## Validation
- npm run lint passes with pre-existing warnings.
- git diff --check passes.
- Bundletool 1.18.2 release asset verified.

Related to #439.