### PR TITLE
fix(ios): require iOS 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ credential validation. See
 
 ## Mobile development
 
+The iOS app requires iOS 15.0 or later.
+
 ### Device and emulator runs
 
 Meteor already tracks both mobile platforms in `.meteor/platforms`. With the

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,11 +5,12 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.4',
+  version: "1.5.4",
 });
 
 App.setPreference("android-targetSdkVersion", "35");
 App.setPreference("android-compileSdkVersion", "35");
+App.setPreference("deployment-target", "15.0", "ios");
 // Preferences per latest Meteor docs
 // Use the brand color (matches SplashScreenBackgroundColor) instead of black so
 // the WebView background shown during hot code push reloads is not a black flash.


### PR DESCRIPTION
## Summary
- set the shared Cordova iOS deployment target to 15.0
- document iOS 15.0 as the minimum supported version
- apply the same setting to production and Beta builds through mobile-config.js

## Validation
- npx eslint mobile-config.js
- pre-commit formatting and lint checks passed

Closes #438