### PR TITLE
Fix Android SDK 36 setup in beta workflow

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -272,8 +272,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Install Android SDK 36
-        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+      - name: Setup Android SDK 36
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0'
 
       - name: Install Meteor
         run: |


### PR DESCRIPTION
## Failure
The Beta Android job failed in the Android SDK installation step with sdkmanager: command not found (exit code 127). The ubuntu-latest runner did not expose Android command-line tools on PATH.

## Fix
- Initialize Android command-line tools with android-actions/setup-android v4.
- Provision platform-tools, Android Platform 36, and Build Tools 36.0.0 through the action.

## Validation
- Confirmed the failed job never reached the Meteor build.
- git diff --check passes.

Fixes the failure in run 31405990352, job 93512455317.
Related to #439.