### PR TITLE
fix(ios): restore iOS 15 deployment target

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,12 +5,13 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.6',
+  version: "1.5.6",
 });
 
 App.setPreference("android-targetSdkVersion", "36");
 App.setPreference("android-compileSdkVersion", "36");
 App.setPreference("android-buildToolsVersion", "36.0.0");
+App.setPreference("deployment-target", "15.0", "ios");
 // Preferences per latest Meteor docs
 // Use the brand color (matches SplashScreenBackgroundColor) instead of black so
 // the WebView background shown during hot code push reloads is not a black flash.


### PR DESCRIPTION
## Summary
- restore the shared Cordova deployment target of iOS 15.0
- retain the Android API 36 settings introduced concurrently

## Root cause
PR #441 added the target, but the subsequent development sync in commit fe6c285 replaced the whole platform-preference block while resolving PR #440, unintentionally removing it. The uploaded 1.5.5 build therefore used Cordova iOS default 11.0.

## Validation
- npx eslint mobile-config.js

Closes #438