### PR TITLE
Admin Diagnostics tab for push-delivery troubleshooting

### DIFF
--- a/client/mobile/diagnostics.js
+++ b/client/mobile/diagnostics.js
@@ -20,6 +20,7 @@ const getDeviceInfo = () => {
     platform: device.platform || "Unknown",
     version: device.version || "Unknown",
     model: device.model || "Unknown",
+    uuid: device.uuid || "Unknown",
   };
 };
 

--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -595,6 +595,11 @@ const DeviceManagementPage = () => {
                       <p className="text-xs text-muted-foreground">
                         Last used: {formatLastUsed(device)}
                       </p>
+                      {isCurrent && (
+                        <p className="text-[10px] text-muted-foreground/70 break-all">
+                          UUID: {device.deviceUUID}
+                        </p>
+                      )}
                       {isApproved && meta.watch && (
                         <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
                           <Watch className="h-3.5 w-3.5" />

--- a/docs/ADMIN_DASHBOARD.md
+++ b/docs/ADMIN_DASHBOARD.md
@@ -41,12 +41,13 @@ No database seeding required — admin access is determined by LDAP group member
 
 ## Dashboard Tabs
 
-| Tab         | Description                                                                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🔑 API Keys | Create / delete client API keys. Key shown once with copy button; list shows first-5-char prefix + masked remainder.                                    |
-| 👤 Users    | List all users with registration status. Approve pending users or delete any user.                                                                      |
-| 📱 Devices  | Devices grouped by user. Approve pending devices or revoke any device.                                                                                  |
-| 📧 Emails   | Log of every outgoing email (registration approval, support, account deletion). Filter by type. Approve / reject users inline from registration emails. |
+| Tab            | Description                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🔑 API Keys    | Create / delete client API keys. Key shown once with copy button; list shows first-5-char prefix + masked remainder.                                                                                                                                                                                                                                                                           |
+| 👤 Users       | List all users with registration status. Approve pending users or delete any user.                                                                                                                                                                                                                                                                                                             |
+| 📱 Devices     | Devices grouped by user. Approve pending devices or revoke any device.                                                                                                                                                                                                                                                                                                                         |
+| 📧 Emails      | Log of every outgoing email (registration approval, support, account deletion). Filter by type. Approve / reject users inline from registration emails.                                                                                                                                                                                                                                        |
+| 🩺 Diagnostics | Look up a user (username / email / userId) to inspect their account, devices, stored FCM token state (masked preview + SHA-256 fingerprint), and recent notification history — without direct MongoDB access. Send a per-device test push to verify the stored token against live FCM (a `registration-token-not-registered` result means the token is stale and the device must re-register). |
 
 ## REST API Reference
 
@@ -89,6 +90,15 @@ All endpoints require `Authorization: Bearer <token>` except login.
 | Method | Path                     | Body | Description                    |
 | ------ | ------------------------ | ---- | ------------------------------ |
 | GET    | `/api/admin/emails/list` | —    | Last 200 emails (newest first) |
+
+### Diagnostics
+
+| Method | Path                               | Body / Query                   | Description                                                                                          |
+| ------ | ---------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| GET    | `/api/admin/diagnostics/user`      | `?q=<username\|email\|userId>` | Account, devices (masked FCM token info, biometric-secret presence), warnings, last 15 notifications |
+| POST   | `/api/admin/diagnostics/test-push` | `{ userId, deviceUUID }`       | Send a test push to the stored token; returns the live FCM result (e.g. stale-token error codes)     |
+
+Full FCM tokens are never returned — only a masked preview (first 12 + last 6 chars), length, and a truncated SHA-256 fingerprint, which is enough to compare against a device's diagnostics logs.
 
 ## Files
 

--- a/root-cause-todo.md
+++ b/root-cause-todo.md
@@ -1,0 +1,47 @@
+# Root Cause TODO
+
+Findings from the 2026-08-07 "push notifications not received" investigation. The admin Diagnostics tab (user lookup + test push) has already shipped; the items below are the underlying fixes still to do.
+
+## 1. Client calls a nonexistent method to persist refreshed FCM tokens
+
+- **Issue:** `client/mobile/push-notifications.js` (`setupRegistrationHandler`) calls `Meteor.call("deviceDetails.storeFCMToken", ...)`, but that method does not exist on the server — it fails with `Method not found [404]` on every app start. Client-writable token methods were deliberately removed (see `tests/deviceManagement.js` "FCM token lookups are no longer exposed as Meteor methods").
+- **Impact:** When FCM rotates a token (reinstall, restore, OS update), the server keeps sending to the stale token and the device silently stops receiving pushes.
+- **Fix:** Add a secure, authenticated token-refresh method that requires the caller's `deviceUUID` (and validates ownership/approved status), then call it from the `registration` handler. Remove or guard the dead `storeFCMToken` call.
+
+## 2. Per-device registration date is not stored
+
+- **Issue:** `registerDeviceDetails` (`utils/api/deviceDetails.js`) never records when a device was registered. Only the user document's top-level `createdAt` (first device) exists; `devices[].lastUpdated` is overwritten by every later mutation.
+- **Impact:** Admins cannot tell when a device was added — useful for diagnostics and security review (e.g. spotting unexpected device additions).
+- **Fix:**
+  - Set `registeredAt: new Date()` in both device-creation paths (first-device insert and the `$push` for additional devices).
+  - Preserve `registeredAt` in the update-existing-device branch (re-registration should not reset it — or decide explicitly that it should).
+  - Expose `registeredAt` in `/api/admin/devices/list` and `/api/admin/diagnostics/user`, and render it in the Devices and Diagnostics tabs.
+  - Backfill note: existing devices have no value — display "unknown" or backfill from `lastUpdated`.
+
+## 3. Unsupported iOS push init options
+
+- **Issue:** `configurePushNotifications` passes `foreground` and `priority` in the iOS init block; the installed plugin logs `Settings: Invalid option key` for both.
+- **Impact:** Harmless, but produces misleading noise in device diagnostics logs.
+- **Fix:** Remove the unsupported keys from the `ios` init options.
+
+## 4. Exposed FCM token from diagnostics logs
+
+- **Issue:** The user's diagnostics log shared on 2026-08-07 contained a full, live FCM registration token.
+- **Fix:** Treat that token as exposed — force the device to re-register (rotates the token) once item 1 lands. Consider redacting FCM tokens in the diagnostics log capture going forward.
+
+## 5. Runaway timeout loop on app resume (2026-08-10 log)
+
+- **Issue:** Resuming the app fired `notificationHistory.updateStatus(..., "timeout")` ~1,400 times in 6 seconds for an already-approved Aug 7 notification (`QJSAZbvA8LSfP5ZKy`). Chain:
+  - `handleAppResume` (`client/mobile/src/ui/hooks/useNotificationHandler.js`) restored a **stale** `pendingNotification` from localStorage — it was never cleared after the notification was approved.
+  - `ActionsModal` opened with the ancient `createdAt`; `calculateInitialTime() <= 0` triggers `handleTimeout()` inside the effect.
+  - `onTimeOut` (`handleTimeout` in `LandingPage.jsx`) is not memoized, and the client method stub's Minimongo write re-renders the page, so the effect re-runs on every render → repeated `updateStatus` calls until the first server ack closes the modal.
+- **Impact:** DDP method flood, and the notification's `approve` status was overwritten to `timeout` (audit trail corrupted).
+- **Fixes:**
+  - Clear `pendingNotification` from localStorage whenever the notification is resolved (approve/reject/timeout), and validate `createdAt` on resume — discard expired entries instead of opening the modal.
+  - Wrap `handleTimeout` in `useCallback` in `LandingPage.jsx`; add a one-shot guard (ref) in `ActionsModal` so `handleTimeout` fires at most once per open.
+  - Server-side: `notificationHistory.updateStatus` (`utils/api/notificationHistory.js`) must require `this.userId`, verify ownership, and only allow `pending → timeout` transitions (never overwrite a handled status). Add a DDP rate limit.
+
+## 6. notificationHistory methods lack authentication
+
+- **Issue:** `notificationHistory.updateStatus`, `getLastIdByUser`, `getByUser`, and `getByStatus` have no `this.userId` / ownership checks — any connected client can read or rewrite any user's notification history by guessing/knowing ids.
+- **Fix:** Require authentication, scope reads to `this.userId`, and validate status transitions server-side.

--- a/server/adminApi.js
+++ b/server/adminApi.js
@@ -1,8 +1,11 @@
 import { Meteor } from "meteor/meteor";
 import { WebApp } from "meteor/webapp";
+import crypto from "crypto";
 import { ApiKeys } from "../utils/api/apiKeys";
 import { DeviceDetails } from "../utils/api/deviceDetails";
 import { EmailLog } from "../utils/api/emailLog";
+import { NotificationHistory } from "../utils/api/notificationHistory";
+import { sendNotification } from "./firebase";
 import {
   requireAdminAuth,
   validateCredentials,
@@ -763,3 +766,254 @@ WebApp.connectHandlers.use("/api/admin/duo/delete", async (req, res) => {
     }
   });
 });
+
+// ─── Diagnostics ──────────────────────────────────────────────────
+// Read-only troubleshooting view of a user's database state, so admins can
+// diagnose push-delivery issues (e.g. stale FCM tokens) without direct
+// MongoDB access.
+
+// Summarise an FCM token without exposing the full send-capable value.
+// The preview (first 12 + last 6 chars) is enough to compare against the
+// token printed in a device's diagnostics logs; the SHA-256 fingerprint
+// allows exact comparison when two previews look alike.
+const fcmTokenInfo = (token) => {
+  if (!token) return { present: false };
+  return {
+    present: true,
+    length: token.length,
+    preview: `${token.slice(0, 12)}…${token.slice(-6)}`,
+    sha256: crypto
+      .createHash("sha256")
+      .update(token)
+      .digest("hex")
+      .slice(0, 16),
+  };
+};
+
+// Look up a user by username, email, or userId and return their account,
+// device, and recent-notification state.
+WebApp.connectHandlers.use("/api/admin/diagnostics/user", async (req, res) => {
+  setCors(res);
+  if (req.method === "OPTIONS") {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+  if (req.method !== "GET")
+    return sendJson(res, 405, { error: "Method not allowed" });
+
+  await requireAdminAuth(req, res, async () => {
+    try {
+      const query = new URL(req.url, "http://localhost").searchParams
+        .get("q")
+        ?.trim();
+      if (!query)
+        return sendJson(res, 400, {
+          error: "Query parameter q (username, email, or userId) required",
+          errorCode: "missing-field",
+        });
+
+      // Case-insensitive exact match on username/email; exact match on _id.
+      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const exact = new RegExp(`^${escaped}$`, "i");
+
+      const user = await Meteor.users.findOneAsync(
+        {
+          $or: [
+            { _id: query },
+            { username: exact },
+            { "emails.address": exact },
+          ],
+        },
+        {
+          fields: {
+            username: 1,
+            emails: 1,
+            profile: 1,
+            createdAt: 1,
+            "services.resume.loginTokens": 1,
+          },
+        },
+      );
+
+      const deviceDoc = await DeviceDetails.findOneAsync({
+        $or: [
+          { userId: user?._id || query },
+          { username: exact },
+          { email: exact },
+        ],
+      });
+
+      if (!user && !deviceDoc)
+        return sendJson(res, 404, {
+          error: "No user or device record matched that query",
+          errorCode: "user-not-found",
+        });
+
+      const userId = user?._id || deviceDoc?.userId;
+
+      const notifications = await NotificationHistory.find(
+        { userId },
+        { sort: { createdAt: -1 }, limit: 15 },
+      ).fetchAsync();
+
+      sendJson(res, 200, {
+        success: true,
+        account: user
+          ? {
+              userId: user._id,
+              username: user.username,
+              email: user.emails?.[0]?.address,
+              registrationStatus: user.profile?.registrationStatus || "pending",
+              createdAt: user.createdAt,
+              activeSessionCount:
+                user.services?.resume?.loginTokens?.length || 0,
+            }
+          : null,
+        deviceRecord: deviceDoc
+          ? {
+              userId: deviceDoc.userId,
+              username: deviceDoc.username,
+              email: deviceDoc.email,
+              lastUpdated: deviceDoc.lastUpdated,
+              devices: (deviceDoc.devices || []).map((d) => ({
+                deviceUUID: d.deviceUUID,
+                appId: d.appId,
+                customName: d.customName,
+                deviceModel: d.deviceModel,
+                devicePlatform: d.devicePlatform,
+                status: d.deviceRegistrationStatus,
+                isPrimary: !!d.isPrimary,
+                lastUsed: d.lastUsed,
+                lastUpdated: d.lastUpdated,
+                hasBiometricSecret: !!d.biometricSecret,
+                fcmToken: fcmTokenInfo(d.fcmToken),
+              })),
+            }
+          : null,
+        // Flag account/device inconsistencies that commonly break pushes.
+        warnings: [
+          user && !deviceDoc && "User exists but has no device record.",
+          deviceDoc &&
+            !user &&
+            "Device record exists but the user account was deleted.",
+          deviceDoc &&
+            (deviceDoc.devices || []).some((d) => !d.fcmToken) &&
+            "One or more devices have no FCM token stored — pushes cannot be delivered to them.",
+          deviceDoc &&
+            (deviceDoc.devices || []).length > 0 &&
+            !(deviceDoc.devices || []).some(
+              (d) => d.deviceRegistrationStatus === "approved" && d.isPrimary,
+            ) &&
+            "No approved primary device — approval pushes may not be routed.",
+        ].filter(Boolean),
+        notifications: notifications.map((n) => ({
+          notificationId: n.notificationId,
+          title: n.title,
+          status: n.status,
+          clientId: n.clientId,
+          createdAt: n.createdAt,
+        })),
+      });
+    } catch (err) {
+      const mapped = mapMeteorError(err);
+      sendJson(res, mapped.status, {
+        error: mapped.error,
+        errorCode: mapped.errorCode,
+      });
+    }
+  });
+});
+
+// Send a test push to one stored device token and report the live FCM
+// result. A "messaging/registration-token-not-registered" error proves the
+// stored token is stale (device reinstalled / token rotated but never
+// re-persisted).
+WebApp.connectHandlers.use(
+  "/api/admin/diagnostics/test-push",
+  async (req, res) => {
+    setCors(res);
+    if (req.method === "OPTIONS") {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    if (req.method !== "POST")
+      return sendJson(res, 405, { error: "Method not allowed" });
+
+    await requireAdminAuth(req, res, async () => {
+      try {
+        const { userId, deviceUUID } = await parseJsonBody(req);
+        if (!userId || !deviceUUID)
+          return sendJson(res, 400, {
+            error: "userId and deviceUUID required",
+            errorCode: "missing-field",
+          });
+
+        const userDoc = await DeviceDetails.findOneAsync({ userId });
+        const device = userDoc?.devices?.find(
+          (d) => d.deviceUUID === deviceUUID,
+        );
+        if (!device)
+          return sendJson(res, 404, {
+            error: "Device not found",
+            errorCode: "device-not-found",
+          });
+        if (!device.fcmToken)
+          return sendJson(res, 200, {
+            success: false,
+            result: "no-token",
+            message: "No FCM token is stored for this device.",
+          });
+
+        try {
+          const messageId = await sendNotification(
+            device.fcmToken,
+            "Test Notification",
+            "This is a diagnostic test push sent by an administrator.",
+            {
+              notificationType: "test",
+              isDismissal: "false",
+              isSync: "false",
+            },
+          );
+          if (!messageId)
+            return sendJson(res, 200, {
+              success: false,
+              result: "firebase-disabled",
+              message:
+                "Firebase is not initialised on this server — push notifications are disabled.",
+            });
+          sendJson(res, 200, {
+            success: true,
+            result: "sent",
+            messageId,
+            message:
+              "FCM accepted the message. If the device did not receive it, check its OS notification permissions.",
+          });
+        } catch (fcmErr) {
+          const code = fcmErr.code || "unknown";
+          const STALE_CODES = [
+            "messaging/registration-token-not-registered",
+            "messaging/invalid-registration-token",
+            "messaging/invalid-argument",
+          ];
+          sendJson(res, 200, {
+            success: false,
+            result: "fcm-error",
+            fcmErrorCode: code,
+            message: STALE_CODES.includes(code)
+              ? "The stored FCM token is stale or invalid — the device must re-register to receive pushes."
+              : `FCM rejected the message: ${fcmErr.message}`,
+          });
+        }
+      } catch (err) {
+        const mapped = mapMeteorError(err);
+        sendJson(res, mapped.status, {
+          error: mapped.error,
+          errorCode: mapped.errorCode,
+        });
+      }
+    });
+  },
+);

--- a/server/diagnostics.js
+++ b/server/diagnostics.js
@@ -30,6 +30,7 @@ Meteor.methods({
         platform: String,
         version: String,
         model: String,
+        uuid: Match.Maybe(String),
       }),
     );
 
@@ -50,7 +51,7 @@ Meteor.methods({
     const normalizedEmail = recipientEmail.trim();
     const attachmentLogs = redactLogs(logs.slice(-MAX_LOG_LENGTH));
     const deviceSummary = device
-      ? `${device.platform} ${device.version} (${device.model})`
+      ? `${device.platform} ${device.version} (${device.model})${device.uuid ? ` — UUID: ${device.uuid}` : ""}`
       : "Unknown device";
     const subject = "MIE Auth diagnostics logs";
 

--- a/server/templates/admin.js
+++ b/server/templates/admin.js
@@ -766,13 +766,170 @@ const EmailsTab = ({ toast, toastErr }) => {
   );
 };
 
-// ─── Dashboard ───────────────────────────────────────────────────
+// ─── Tab: Diagnostics ────────────────────────────────────────
+const DiagnosticsTab = ({ toast, toastErr }) => {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [pushResults, setPushResults] = useState({});
+  const [pushing, setPushing] = useState(null);
+
+  const lookup = async (e) => {
+    if (e) e.preventDefault();
+    if (!query.trim()) return;
+    setLoading(true);
+    setData(null);
+    setNotFound(false);
+    setPushResults({});
+    try {
+      const res = await api('/api/admin/diagnostics/user?q=' + encodeURIComponent(query.trim()));
+      if (res.success) setData(res);
+    } catch (err) {
+      if (err.status === 404) setNotFound(true);
+      else toastErr(err.message || 'Lookup failed', 'error', err);
+    }
+    setLoading(false);
+  };
+
+  const testPush = async (userId, deviceUUID) => {
+    setPushing(deviceUUID);
+    try {
+      const res = await api('/api/admin/diagnostics/test-push', { method: 'POST', body: JSON.stringify({ userId, deviceUUID }) });
+      setPushResults(prev => ({ ...prev, [deviceUUID]: res }));
+      toast(res.success ? 'Test push accepted by FCM' : 'Test push failed — see result below', res.success ? 'success' : 'warning');
+    } catch (err) {
+      toastErr(err.message || 'Test push failed', 'error', err);
+    }
+    setPushing(null);
+  };
+
+  const statusBadge = (status) => {
+    const colors = { approved: 'bg-green-100 text-green-700', pending: 'bg-yellow-100 text-yellow-700', approve: 'bg-green-100 text-green-700', reject: 'bg-red-100 text-red-700', rejected: 'bg-red-100 text-red-700', dismissed: 'bg-gray-100 text-gray-600' };
+    return <span className={\`text-xs px-2 py-0.5 rounded-full font-medium \${colors[status] || 'bg-gray-100 text-gray-600'}\`}>{status}</span>;
+  };
+
+  return (
+    <div className="space-y-6 fade-in">
+      {/* Search */}
+      <div className="bg-white rounded-xl shadow-sm border p-5">
+        <h3 className="font-semibold text-gray-900 mb-1">User Diagnostics</h3>
+        <p className="text-xs text-gray-500 mb-3">Inspect a user's account, devices, FCM token state, and recent notifications — e.g. to troubleshoot pushes that are not being delivered.</p>
+        <form onSubmit={lookup} className="flex gap-3">
+          <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Username, email, or userId" className="flex-1 px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none" />
+          <button type="submit" disabled={loading || !query.trim()} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 text-white text-sm rounded-lg">{loading ? <span className="spinner" /> : 'Look up'}</button>
+        </form>
+        {notFound && <p className="text-sm text-red-500 mt-3">No user or device record matched that query.</p>}
+      </div>
+
+      {data && (
+        <React.Fragment>
+          {/* Warnings */}
+          {data.warnings.length > 0 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4">
+              <p className="text-xs font-semibold text-yellow-800 mb-1">⚠️ Potential issues</p>
+              <ul className="list-disc ml-5 space-y-0.5">
+                {data.warnings.map((w, i) => <li key={i} className="text-xs text-yellow-800">{w}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* Account */}
+          <div className="bg-white rounded-xl shadow-sm border">
+            <div className="px-5 py-4 border-b"><h3 className="font-semibold text-gray-900">Account</h3></div>
+            {data.account ? (
+              <div className="px-5 py-4 grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 text-sm">
+                <div><p className="text-xs text-gray-400">Username</p><p className="text-gray-900">{data.account.username}</p></div>
+                <div><p className="text-xs text-gray-400">Email</p><p className="text-gray-900 truncate">{data.account.email || '—'}</p></div>
+                <div><p className="text-xs text-gray-400">Status</p>{statusBadge(data.account.registrationStatus)}</div>
+                <div><p className="text-xs text-gray-400">User ID</p><code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">{data.account.userId}</code></div>
+                <div><p className="text-xs text-gray-400">Active sessions</p><p className="text-gray-900">{data.account.activeSessionCount}</p></div>
+                <div><p className="text-xs text-gray-400">Created</p><p className="text-gray-900">{data.account.createdAt ? new Date(data.account.createdAt).toLocaleString() : '—'}</p></div>
+              </div>
+            ) : <p className="p-5 text-sm text-red-500">No user account found (device record is orphaned).</p>}
+          </div>
+
+          {/* Devices */}
+          <div className="bg-white rounded-xl shadow-sm border">
+            <div className="px-5 py-4 border-b flex items-center justify-between">
+              <h3 className="font-semibold text-gray-900">Devices &amp; Push Tokens</h3>
+              {data.deviceRecord && <span className="text-xs text-gray-400">Record updated: {data.deviceRecord.lastUpdated ? new Date(data.deviceRecord.lastUpdated).toLocaleString() : '—'}</span>}
+            </div>
+            {!data.deviceRecord || data.deviceRecord.devices.length === 0 ? (
+              <p className="p-8 text-center text-gray-400 text-sm">No devices registered</p>
+            ) : (
+              <div className="divide-y">
+                {data.deviceRecord.devices.map((d) => {
+                  const pr = pushResults[d.deviceUUID];
+                  return (
+                    <div key={d.deviceUUID} className="px-5 py-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm text-gray-900 font-medium">
+                            {d.customName || d.deviceModel || 'Unknown'} ({d.devicePlatform || '?'})
+                            {' '}{statusBadge(d.status)}
+                            {d.isPrimary && <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full ml-1">Primary</span>}
+                          </p>
+                          <p className="text-xs text-gray-500 mt-1">UUID: <code className="bg-gray-100 px-1 py-0.5 rounded">{d.deviceUUID}</code></p>
+                          <p className="text-xs text-gray-500 mt-1">
+                            FCM token: {d.fcmToken.present
+                              ? <React.Fragment><code className="bg-gray-100 px-1 py-0.5 rounded">{d.fcmToken.preview}</code> · {d.fcmToken.length} chars · sha256 <code className="bg-gray-100 px-1 py-0.5 rounded">{d.fcmToken.sha256}</code></React.Fragment>
+                              : <span className="text-red-500 font-medium">missing</span>}
+                          </p>
+                          <p className="text-xs text-gray-400 mt-1">
+                            Biometric secret: {d.hasBiometricSecret ? 'stored' : 'missing'} · Last used: {d.lastUsed ? new Date(d.lastUsed).toLocaleString() : 'never'} · Updated: {d.lastUpdated ? new Date(d.lastUpdated).toLocaleString() : '—'}
+                          </p>
+                          {pr && (
+                            <div className={\`mt-2 text-xs rounded-lg px-3 py-2 border \${pr.success ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-700'}\`}>
+                              <span className="font-semibold">{pr.success ? '✓ Sent' : '✗ ' + (pr.fcmErrorCode || pr.result)}</span> — {pr.message}
+                            </div>
+                          )}
+                        </div>
+                        <button onClick={() => testPush(data.deviceRecord.userId, d.deviceUUID)} disabled={pushing === d.deviceUUID || !d.fcmToken.present}
+                          className="shrink-0 text-blue-600 hover:text-blue-800 disabled:text-gray-300 text-xs font-medium px-3 py-1 rounded border border-blue-200 hover:bg-blue-50">
+                          {pushing === d.deviceUUID ? <span className="spinner" /> : 'Send test push'}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Recent notifications */}
+          <div className="bg-white rounded-xl shadow-sm border">
+            <div className="px-5 py-4 border-b"><h3 className="font-semibold text-gray-900">Recent Notifications</h3></div>
+            {data.notifications.length === 0 ? (
+              <p className="p-8 text-center text-gray-400 text-sm">No notification history</p>
+            ) : (
+              <div className="divide-y">
+                {data.notifications.map((n) => (
+                  <div key={n.notificationId} className="px-5 py-2.5 flex items-center justify-between gap-4 hover:bg-gray-50">
+                    <div className="min-w-0">
+                      <p className="text-sm text-gray-900 truncate">{n.title}</p>
+                      <p className="text-xs text-gray-400">{new Date(n.createdAt).toLocaleString()}{n.clientId ? \` · \${n.clientId}\` : ''}</p>
+                    </div>
+                    {statusBadge(n.status)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </React.Fragment>
+      )}
+    </div>
+  );
+};
+
+// ─── Dashboard ─────────────────────────────────────────────────
 const TABS = [
   { id: 'keys', label: 'API Keys', icon: '🔑' },
   { id: 'duo', label: 'Duo', icon: '🔐' },
   { id: 'users', label: 'Users', icon: '👤' },
   { id: 'devices', label: 'Devices', icon: '📱' },
-  { id: 'emails', label: 'Emails', icon: '📧' }
+  { id: 'emails', label: 'Emails', icon: '📧' },
+  { id: 'diagnostics', label: 'Diagnostics', icon: '🩺' }
 ];
 
 const Dashboard = ({ adminId, onLogout }) => {
@@ -818,6 +975,7 @@ const Dashboard = ({ adminId, onLogout }) => {
         {tab === 'users' && <UsersTab toast={toast} toastErr={toastWithSessionCheck} />}
         {tab === 'devices' && <DevicesTab toast={toast} toastErr={toastWithSessionCheck} />}
         {tab === 'emails' && <EmailsTab toast={toast} toastErr={toastWithSessionCheck} />}
+        {tab === 'diagnostics' && <DiagnosticsTab toast={toast} toastErr={toastWithSessionCheck} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds an admin **Diagnostics** tab so push-delivery issues (like the "notifications not received" report from 2026-08-07) can be investigated without direct production MongoDB access, plus device UUID visibility on both ends, and a root-cause TODO from the investigation.

## Changes

### Admin dashboard — Diagnostics tab
- Look up a user by username, email, or userId and view:
  - Account state (registration status, active session count, created date)
  - Devices with masked FCM token info (first 12 + last 6 chars, length, truncated SHA-256 fingerprint — full tokens are never returned)
  - Auto-flagged warnings (missing FCM token, no approved primary device, orphaned records)
  - Last 15 notification history entries
- Per-device **Send test push** button — sends to the stored token and reports the live FCM result; `messaging/registration-token-not-registered` conclusively identifies a stale token

### Admin API
- `GET /api/admin/diagnostics/user?q=<username|email|userId>`
- `POST /api/admin/diagnostics/test-push` `{ userId, deviceUUID }`
- Both require admin Bearer auth (same `requireAdminAuth` middleware as existing endpoints)

### Device UUID visibility
- My Devices: current device card now shows its full `deviceUUID` so users can confirm it matches the registered record
- Diagnostics logs: device UUID included in the payload and email summary line

### Docs
- `docs/ADMIN_DASHBOARD.md` updated with the new tab and endpoints
- `root-cause-todo.md`: documented findings from the push investigation — dead `deviceDetails.storeFCMToken` call (root cause), missing per-device `registeredAt`, invalid iOS init options, exposed token rotation, resume-triggered timeout loop, and unauthenticated `notificationHistory` methods

## Motivation

A user reported pushes not arriving. Device logs showed successful APNs/FCM registration but `Method 'deviceDetails.storeFCMToken' not found [404]` on every launch — refreshed FCM tokens are never persisted, so the server sends to stale tokens. Verifying this previously required production DB access; this PR makes it a two-click admin operation.

## Testing

- `npx eslint` and `npx prettier --check` pass on all changed files
- Diagnostics lookup exercised against username/email/userId inputs
- Test-push verified to surface FCM error codes for stale/missing tokens
