### PR TITLE
Reconcile rotated FCM tokens with the server (fixes #449)

### DIFF
--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
+import { Tracker } from "meteor/tracker";
 import { IOS_APPROVAL_CATEGORIES } from "../../utils/constants.js";
 
 // Session validation with retry logic
@@ -134,7 +135,39 @@ const configurePushNotifications = () => {
 const setupRegistrationHandler = (push) => {
   push.on("registration", (data) => {
     Session.set("deviceToken", data.registrationId);
-    Meteor.call("deviceDetails.storeFCMToken", data.registrationId);
+  });
+};
+
+// Last (user, device, token) combination successfully sent to the server, so
+// the autorun below doesn't repeat the call on unrelated reactive changes.
+let lastReconciledKey = null;
+
+// Keep the server's stored FCM token in sync with the live one. Tokens rotate
+// (reinstall, OS restore, Firebase refresh) and a stale stored token means
+// pushes silently stop. Reactive on login state, captured device info and the
+// token itself, so it works regardless of which becomes available first.
+const setupTokenReconciliation = () => {
+  Tracker.autorun(() => {
+    const userId = Meteor.userId();
+    const fcmToken = Session.get("deviceToken");
+    const deviceUUID = Session.get("capturedDeviceInfo")?.uuid;
+
+    if (!userId || !fcmToken || !deviceUUID) return;
+
+    const key = `${userId}:${deviceUUID}:${fcmToken}`;
+    if (key === lastReconciledKey) return;
+    lastReconciledKey = key;
+
+    Meteor.call("devices.updateFCMToken", { deviceUUID, fcmToken }, (error) => {
+      if (error) {
+        // Allow a retry on the next reactive change (e.g. re-login).
+        lastReconciledKey = null;
+        console.warn(
+          "FCM token reconciliation failed:",
+          error.reason || error.message,
+        );
+      }
+    });
   });
 };
 
@@ -317,6 +350,7 @@ export const initializePushNotifications = () => {
 
     // Register handlers
     setupRegistrationHandler(push);
+    setupTokenReconciliation();
     setupActionHandlers(push);
     setupNotificationHandler(push);
     setupErrorHandler(push);

--- a/migration-plan.md
+++ b/migration-plan.md
@@ -1,0 +1,171 @@
+# Device Identity Migration Plan
+
+Goal: move device trust from the Cordova `device.uuid` (which survives iCloud/Android
+backup restores) to a **non-migrating installation identity**, without forcing every
+existing user through re-approval.
+
+A restored replacement phone must become a **pending device**; an actively used phone
+must migrate **silently**.
+
+## Background — why
+
+- Trust is currently keyed by `device.uuid` captured in
+  [client/mobile/capture-device-info.js](client/mobile/capture-device-info.js), which can
+  survive a backup restore onto a different physical phone.
+- Login only checks the account-level `profile.registrationStatus`
+  ([client/mobile/src/ui/Login.jsx](client/mobile/src/ui/Login.jsx)), not whether _this_
+  device is approved.
+- The startup token-refresh call `deviceDetails.storeFCMToken`
+  ([client/mobile/push-notifications.js](client/mobile/push-notifications.js#L137)) has
+  **no matching server method** — rotated FCM tokens are never reconciled.
+- `users.mapFCMTokenToUser` in [server/main.js](server/main.js) queries `fcmToken` at the
+  document root, but tokens live under `devices[]` — dead code for the current schema.
+
+## Migration proofs (decision table)
+
+A device may be silently grandfathered ("v2 approved") only by proving possession of
+something that stays on the original physical phone:
+
+| Proof presented                                                                         | Result                   |
+| --------------------------------------------------------------------------------------- | ------------------------ |
+| Biometric secret (Keychain `ThisDeviceOnly`) matches stored `devices[].biometricSecret` | Silent migration         |
+| Device receives a challenge pushed to the **old FCM token stored in Mongo**             | Silent migration         |
+| Only UUID / localStorage / resume token / PIN                                           | Pending — needs approval |
+| Nothing                                                                                 | Pending — needs approval |
+
+---
+
+## Phase 0 — Fix existing gaps (prerequisite, no behavior change)
+
+- [x] Remove the dead `Meteor.call("deviceDetails.storeFCMToken", ...)` in
+      [client/mobile/push-notifications.js](client/mobile/push-notifications.js#L137)
+      (it silently fails today) — it will be replaced in Phase 2.
+- [x] Delete the broken `users.mapFCMTokenToUser` method in
+      [server/main.js](server/main.js) (queries root-level `fcmToken`, never matches the
+      nested schema). Confirm no client callers with a workspace-wide grep first.
+- [ ] Verify the biometric Keychain item is actually non-migrating on iOS:
+      check what accessibility class `cordova-plugin-fingerprint-aio`'s
+      `registerBiometricSecret({ disableBackup: true })` uses. Document the finding in
+      this file. If it is NOT `...ThisDeviceOnly`, the FCM-challenge proof becomes the
+      primary silent-migration path.
+- [x] Add a `devices.updateFCMToken` Meteor method (server) that: - requires `this.userId` - takes `{ deviceUUID, fcmToken }` with `check(...)` - updates only the matching device **owned by the caller** - never changes `deviceRegistrationStatus` - rate-limit it via `DDPRateLimiter` like the methods in
+      [server/deviceManagement.js](server/deviceManagement.js)
+- [x] Call `devices.updateFCMToken` from the push `registration` handler in
+      [client/mobile/push-notifications.js](client/mobile/push-notifications.js), only
+      when a user is logged in (`Meteor.userId()`); otherwise store in Session and flush
+      after login.
+- [x] Add a test in [tests/deviceManagement.js](tests/deviceManagement.js): token update
+      succeeds for own device, fails for another user's device, fails logged out, and
+      does not modify `deviceRegistrationStatus`.
+
+## Phase 1 — Server: v2 installation identity (additive only)
+
+- [ ] Extend the device schema in
+      [utils/api/deviceDetails.js](utils/api/deviceDetails.js) with new optional fields:
+      `installationId`, `publicKey`, `identityVersion` (1 = legacy, 2 = migrated),
+      `migratedAt`, `migrationProof` (`"biometric" | "fcm-challenge" | "manual-approval"`).
+- [ ] Create `MigrationChallenges` collection (`utils/api/migrationChallenges.js`):
+      `{ userId, deviceUUID, challenge, createdAt, expiresAt (5 min), usedAt }` with a
+      TTL index on `expiresAt`.
+- [ ] Add method `devices.beginIdentityMigration({ deviceUUID, installationId, publicKey })`: - requires `this.userId` - device must exist, belong to caller, and be `approved` - device must not already have `identityVersion: 2` - creates a challenge record and returns `{ challengeId }` (NOT the challenge value)
+- [ ] Add method `devices.proveMigrationByBiometric({ challengeId, biometricSecret, signedChallenge })`: - timing-safe compare of `biometricSecret` against the stored device secret
+      (reuse the pattern in [server/deviceManagement.js](server/deviceManagement.js#L80)) - verify `signedChallenge` against the submitted `publicKey` - on success: set `identityVersion: 2`, `migrationProof: "biometric"`, bind
+      `installationId`/`publicKey`, mark challenge used
+- [ ] Add method `devices.requestMigrationPushChallenge({ challengeId })`: - sends the challenge value via `sendNotification` (see
+      [server/firebase.js](server/firebase.js)) as a **data-only** push to the FCM
+      token **already stored in Mongo** for that device — never to a token supplied by
+      the caller
+- [ ] Add method `devices.proveMigrationByPush({ challengeId, challengeValue, signedChallenge })`: - challenge value must match, be unexpired and unused - verify signature; on success set `identityVersion: 2`,
+      `migrationProof: "fcm-challenge"`, bind identity, mark used
+- [ ] Only after successful migration may `devices.updateFCMToken` replace the stored
+      token for that device (update the Phase 0 method to enforce this once Phase 3
+      client code ships).
+- [ ] Signature scheme: ECDSA P-256, SHA-256 over the raw challenge bytes; verify with
+      Node `crypto.verify`. Public key transported as base64 SPKI DER.
+- [ ] Tests in [tests/deviceManagement.js](tests/deviceManagement.js): expired challenge
+      rejected, reused challenge rejected, wrong signature rejected, cross-user attempt
+      rejected, successful biometric path, successful push path.
+
+## Phase 2 — Client: generate identity + silent migration
+
+- [ ] Add a Cordova-compatible keypair module `client/mobile/installation-identity.js`: - generate an ECDSA P-256 keypair via WebCrypto (`crypto.subtle`), marked
+      non-extractable where possible - persist via a secure-storage plugin with iOS `ThisDeviceOnly` accessibility;
+      fall back to documenting the storage guarantee actually achieved - expose `getOrCreateIdentity()` → `{ installationId, publicKeyB64, sign(bytes) }`
+- [ ] On app start after login (hook into the dashboard-load path used by
+      `devices.checkRegistrationByUUID` /
+      [client/mobile/src/ui/hooks/useDeviceRegistration.js](client/mobile/src/ui/hooks/useDeviceRegistration.js)):
+      if this device is approved and has no v2 identity, run the migration flow
+      automatically — no UI unless it fails.
+- [ ] Migration flow order: 1. `devices.beginIdentityMigration` 2. try biometric proof (reuse `loadBiometricSecret` pattern from
+      [client/mobile/src/ui/Login.jsx](client/mobile/src/ui/Login.jsx)) 3. if biometric unavailable → `devices.requestMigrationPushChallenge`, listen for
+      the data push in
+      [client/mobile/push-notifications.js](client/mobile/push-notifications.js)
+      (`notificationType: "migration_challenge"`), then `devices.proveMigrationByPush` 4. if both fail → do nothing yet (Phase 4 adds the fallback UI)
+- [ ] Retry at most once per app launch; never block the UI on migration.
+- [ ] Add a `migration_challenge` branch to the notification handler that does NOT
+      surface a banner/modal (data-only handling).
+
+## Phase 3 — Observation rollout
+
+- [ ] Add counters the admin can read (extend
+      [server/adminApi.js](server/adminApi.js) diagnostics): totals of devices at
+      `identityVersion` 1 vs 2, and counts per `migrationProof`.
+- [ ] Add a `migrationEvents` capped log (userId, deviceUUID, outcome, error) for
+      debugging failed silent migrations.
+- [ ] Ship the release. Wait until v2 coverage is high (target: >90% of devices active
+      in the last 30 days) before Phase 5. Check weekly via the admin diagnostics tab.
+- [ ] Fix the top recurring failure causes seen in `migrationEvents`.
+
+## Phase 4 — Fallback UX for unproven devices
+
+- [ ] Add an in-app notice for approved-but-unmigrated devices after N failed silent
+      attempts: "We couldn't verify this installation" with actions: - request approval from another approved device (reuse the secondary-approval
+      push flow in [server/firebase.js](server/firebase.js)
+      `sendSecondaryDeviceApprovalRequest`) - contact admin (existing admin approval flow in [server/main.js](server/main.js))
+- [ ] Approval via either path sets `identityVersion: 2`,
+      `migrationProof: "manual-approval"` and binds the new installation identity.
+- [ ] Add "Mark as lost" to
+      [client/mobile/src/ui/DeviceManagementPage.jsx](client/mobile/src/ui/DeviceManagementPage.jsx):
+      revokes the device (existing revocation path in
+      [server/deviceManagement.js](server/deviceManagement.js)), clears its resume
+      tokens, and removes its FCM token.
+
+## Phase 5 — Enforcement
+
+- [ ] `devices.updateFCMToken`: require `identityVersion: 2` + a signed challenge.
+- [ ] `notifications.handleResponse` ([server/main.js](server/main.js)): require the
+      responding device to be v2 and verify a signature over
+      `notificationId + action`.
+- [ ] Login: after `checkRegistrationStatus`, also verify the **current device** is
+      approved and v2 (new method `devices.checkDeviceApproval({ deviceUUID })`) — fixes
+      the account-level-only check in
+      [client/mobile/src/ui/Login.jsx](client/mobile/src/ui/Login.jsx).
+- [ ] Device management methods (rename, revoke, set-primary in
+      [server/deviceManagement.js](server/deviceManagement.js)): require v2 identity of
+      the acting device.
+- [ ] Announce a migration deadline in-app for remaining v1 devices.
+- [ ] After the deadline: v1 devices are treated as `pending` (blocked from approvals)
+      and must use the Phase 4 fallback.
+
+## Phase 6 — Cleanup
+
+- [ ] Remove v1 acceptance paths and the `identityVersion` branches that tolerate
+      missing identities.
+- [ ] Remove `device.uuid` from any security decision (keep it as display metadata
+      only).
+- [ ] Delete migration counters/log once stable.
+- [ ] Update [docs/](docs/) with the final device-trust model.
+
+---
+
+## Invariants (check on every PR in this plan)
+
+- FCM tokens are **data**, not identity — rotating a token never changes approval.
+- The server never sends a migration challenge to a client-supplied token — only to the
+  token already stored in Mongo.
+- No new publication or method may expose `biometricSecret`, `fcmToken`, `publicKey`
+  challenges, or private keys to clients (see the projection pattern in
+  [utils/api/deviceDetails.js](utils/api/deviceDetails.js)).
+- Silent migration must never downgrade an approved device; failure leaves state
+  unchanged.
+- A backup-restored phone (new keychain, new FCM token) must end up `pending`.

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: "1.5.8",
+  version: "1.5.9",
 });
 
 App.setPreference("android-targetSdkVersion", "36");

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -745,6 +745,45 @@ Meteor.methods({
 
     return { success: true, approved: approve };
   },
+
+  /**
+   * Reconcile a rotated FCM registration token for the calling user's own
+   * device. Tokens rotate legitimately (reinstall, OS restore, Firebase
+   * refresh), so this only replaces the stored token — it never changes the
+   * device's registration/approval status.
+   */
+  async "devices.updateFCMToken"(options) {
+    check(options, { deviceUUID: String, fcmToken: String });
+    requireLogin(this);
+
+    const { deviceUUID, fcmToken } = options;
+
+    if (!fcmToken || fcmToken.length > 4096) {
+      throw new Meteor.Error("invalid-token", "Invalid FCM token.");
+    }
+
+    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+    const device = userDoc?.devices?.find((d) => d.deviceUUID === deviceUUID);
+
+    // No-op rather than an error: the device may have been revoked while the
+    // app was offline, and the client fires this on every push registration.
+    if (!device || device.fcmToken === fcmToken) {
+      return { success: true, updated: false };
+    }
+
+    await DeviceDetails.updateAsync(
+      { userId: this.userId, "devices.deviceUUID": deviceUUID },
+      {
+        $set: {
+          "devices.$.fcmToken": fcmToken,
+          "devices.$.lastUpdated": new Date(),
+          lastUpdated: new Date(),
+        },
+      },
+    );
+
+    return { success: true, updated: true };
+  },
 });
 
 // Brute-force protection for authentication and device management methods.
@@ -753,6 +792,7 @@ const RATE_LIMITED_METHODS = new Set([
   "users.register",
   "devices.checkRegistrationByUUID",
   "devices.updateInfo",
+  "devices.updateFCMToken",
   "devices.rename",
   "devices.setPrimary",
   "devices.revoke",

--- a/server/main.js
+++ b/server/main.js
@@ -2065,39 +2065,6 @@ Meteor.methods({
   },
 
   /**
-   * Map FCM token to user
-   * @param {String} userId - User ID
-   * @param {String} fcmToken - FCM token
-   * @returns {Object} Result
-   */
-  async "users.mapFCMTokenToUser"(userId, fcmToken) {
-    check(userId, String);
-    check(fcmToken, String);
-
-    if (!this.userId) {
-      throw new Meteor.Error("not-authorized", "User must be logged in");
-    }
-
-    const user = Meteor.users.findOne(userId);
-    if (!user) {
-      throw new Meteor.Error("user-not-found", "User not found");
-    }
-
-    // Find device log with this FCM token
-    const deviceLog = await DeviceDetails.findOneAsync({ userId, fcmToken });
-
-    // If device log exists, update it, otherwise create a new entry
-    if (deviceLog) {
-      await DeviceDetails.updateAsync(
-        { _id: deviceLog._id },
-        { $set: { fcmToken: fcmToken, lastUpdated: new Date() } },
-      );
-    }
-
-    return { success: true };
-  },
-
-  /**
    * Check if any users exist in the system
    * @returns {Boolean} Whether users exist
    */

--- a/tests/deviceManagement.js
+++ b/tests/deviceManagement.js
@@ -140,6 +140,85 @@ if (Meteor.isServer) {
       });
     });
 
+    describe("devices.updateFCMToken", function () {
+      it("rejects unauthenticated callers", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: null },
+            { deviceUUID: "uuid-primary", fcmToken: "fcm-rotated" },
+          ),
+          /not-authorized/,
+        );
+      });
+
+      it("updates the token for the caller's own device", async function () {
+        const result = await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_A },
+          { deviceUUID: "uuid-primary", fcmToken: "fcm-rotated" },
+        );
+        assert.strictEqual(result.updated, true);
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-primary");
+        assert.strictEqual(device.fcmToken, "fcm-rotated");
+      });
+
+      it("never changes the device registration status", async function () {
+        await DeviceDetails.updateAsync(
+          { userId: USER_A, "devices.deviceUUID": "uuid-secondary" },
+          { $set: { "devices.$.deviceRegistrationStatus": "pending" } },
+        );
+
+        await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_A },
+          { deviceUUID: "uuid-secondary", fcmToken: "fcm-rotated" },
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find(
+          (d) => d.deviceUUID === "uuid-secondary",
+        );
+        assert.strictEqual(device.fcmToken, "fcm-rotated");
+        assert.strictEqual(device.deviceRegistrationStatus, "pending");
+      });
+
+      it("does not touch another user's device", async function () {
+        const result = await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_B },
+          { deviceUUID: "uuid-primary", fcmToken: "fcm-hijack" },
+        );
+        assert.strictEqual(result.updated, false);
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-primary");
+        assert.strictEqual(device.fcmToken, "fcm-primary");
+      });
+
+      it("is a no-op when the token is unchanged", async function () {
+        const result = await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_A },
+          { deviceUUID: "uuid-primary", fcmToken: "fcm-primary" },
+        );
+        assert.strictEqual(result.updated, false);
+      });
+
+      it("rejects an oversized token", async function () {
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: USER_A },
+            { deviceUUID: "uuid-primary", fcmToken: "x".repeat(4097) },
+          ),
+          /invalid-token/,
+        );
+      });
+    });
+
     describe("devices.updateInfo", function () {
       it("updates the calling device's model/platform and lastUsed", async function () {
         await callMethod(


### PR DESCRIPTION
Fixes #449

## Problem

Rotated FCM registration tokens were never reconciled with the server. The client called `deviceDetails.storeFCMToken` on every push registration event, but **that server method does not exist** — it 404ed silently on every app start (no error callback). Once a device's token rotated (reinstall, OS restore, Firebase refresh), pushes silently stopped until the user re-registered.

A second method, `users.mapFCMTokenToUser`, queried `fcmToken` at the document root even though tokens live under the nested `devices[]` array — dead code with no callers.

## Changes

### Server (`server/deviceManagement.js`)
- New `devices.updateFCMToken` method following the existing self-service device-management patterns:
  - requires an authenticated session (`requireLogin`)
  - `check`-validated `{ deviceUUID, fcmToken }` + token length cap
  - owner-scoped query — can only ever touch the caller's own device
  - **never mutates `deviceRegistrationStatus`** (token rotation must not change trust)
  - no-op (not an error) for unknown/revoked devices and unchanged tokens, since the client fires on every push registration
  - added to the existing `DDPRateLimiter` rule
- Write-only by design: no method returns a token, keeping the "FCM token lookups are not exposed" invariant intact.

### Client (`client/mobile/push-notifications.js`)
- Removed the dead `deviceDetails.storeFCMToken` call.
- Added a `Tracker.autorun` reconciler reactive on login state × captured device info × current token, so it works regardless of which becomes available first (token-before-login and login-before-token). Dedupes per `(user, device, token)` and retries on the next reactive change after a failure.

### Removed (`server/main.js`)
- Deleted broken `users.mapFCMTokenToUser`.

### Other
- `migration-plan.md`: phased device-identity migration plan; Phase 0 items delivered here are checked off.
- Mobile app version bumped to 1.5.9.

## Tests

6 new mocha tests in `tests/deviceManagement.js` (all passing):
- rejects unauthenticated callers
- updates the token for the caller's own device
- never changes the device registration status
- does not touch another user's device (cross-user isolation)
- no-op when the token is unchanged
- rejects an oversized token

`npm test`: 108 passing; the 6 failures are pre-existing in `tests/main.js` (methods only loaded in full-app test mode, `Random is not defined`) and untouched by this PR. ESLint clean on all changed files.

## Security notes

- Token accepted only for a device already registered to the calling user — no cross-account writes possible.
- Rate-limited alongside the other device-management methods.
- FCM tokens remain server-internal (never published or returned to clients).
