### PR TITLE
Identity migration Phase 1: server-side v2 installation identity (closes #452)

### DIFF
--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -56,7 +56,7 @@ const REAUTH_PATTERN = Match.OneOf(
 /**
  * Constant-time string comparison (hash first so lengths never leak).
  */
-const timingSafeEquals = (a, b) => {
+export const timingSafeEquals = (a, b) => {
   const hashA = crypto.createHash("sha256").update(String(a)).digest();
   const hashB = crypto.createHash("sha256").update(String(b)).digest();
   return crypto.timingSafeEqual(hashA, hashB);

--- a/server/identityMigration.js
+++ b/server/identityMigration.js
@@ -1,0 +1,305 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
+import { Random } from "meteor/random";
+import crypto from "crypto";
+import { DeviceDetails } from "../utils/api/deviceDetails.js";
+import { MigrationChallenges } from "../utils/api/migrationChallenges.js";
+import { timingSafeEquals } from "./deviceManagement.js";
+import { sendNotification } from "./firebase.js";
+
+/**
+ * v1 -> v2 installation-identity migration (migration-plan.md Phase 1).
+ *
+ * A v2 device is bound to an ECDSA P-256 keypair generated on the device
+ * (private key non-extractable, never sent to the server). An approved v1
+ * device may be silently upgraded by proving possession of something that
+ * stays on the original physical phone:
+ *  - the device-bound biometric secret, or
+ *  - a challenge delivered via FCM to the token already stored in Mongo.
+ * Backup-restored replacement phones have neither, so they cannot inherit
+ * trust and must go through manual approval (Phase 4).
+ */
+
+const CHALLENGE_EXPIRY_MS = 5 * 60 * 1000;
+
+const asP256KeyObject = (publicKeyB64) => {
+  try {
+    const keyObject = crypto.createPublicKey({
+      key: Buffer.from(publicKeyB64, "base64"),
+      format: "der",
+      type: "spki",
+    });
+    const isP256 =
+      keyObject.asymmetricKeyType === "ec" &&
+      keyObject.asymmetricKeyDetails?.namedCurve === "prime256v1";
+    return isP256 ? keyObject : null;
+  } catch {
+    return null;
+  }
+};
+
+// WebCrypto ECDSA produces IEEE P1363 (r||s) signatures over SHA-256.
+const verifySignature = (publicKeyB64, message, signatureB64) => {
+  const keyObject = asP256KeyObject(publicKeyB64);
+  if (!keyObject) return false;
+  try {
+    return crypto.verify(
+      "sha256",
+      Buffer.from(message, "utf8"),
+      { key: keyObject, dsaEncoding: "ieee-p1363" },
+      Buffer.from(signatureB64, "base64"),
+    );
+  } catch {
+    return false;
+  }
+};
+
+const requireLogin = (context) => {
+  if (!context.userId) {
+    throw new Meteor.Error(
+      "not-authorized",
+      "You must be signed in to migrate this device.",
+    );
+  }
+};
+
+const getLiveChallengeOrThrow = async (userId, challengeId) => {
+  const challenge = await MigrationChallenges.findOneAsync({
+    _id: challengeId,
+    userId,
+  });
+  if (!challenge || challenge.usedAt || challenge.expiresAt <= new Date()) {
+    throw new Meteor.Error(
+      "challenge-invalid",
+      "The migration challenge is invalid or expired. Please start over.",
+    );
+  }
+  return challenge;
+};
+
+// Single-use guard: only the first concurrent prover can flip usedAt.
+const consumeChallenge = async (challengeId) => {
+  const updated = await MigrationChallenges.updateAsync(
+    { _id: challengeId, usedAt: null },
+    { $set: { usedAt: new Date() } },
+  );
+  if (updated !== 1) {
+    throw new Meteor.Error(
+      "challenge-invalid",
+      "The migration challenge was already used. Please start over.",
+    );
+  }
+};
+
+const bindIdentity = async (userId, challenge, migrationProof) => {
+  await DeviceDetails.updateAsync(
+    { userId, "devices.deviceUUID": challenge.deviceUUID },
+    {
+      $set: {
+        "devices.$.installationId": challenge.installationId,
+        "devices.$.publicKey": challenge.publicKey,
+        "devices.$.identityVersion": 2,
+        "devices.$.migratedAt": new Date(),
+        "devices.$.migrationProof": migrationProof,
+        "devices.$.lastUpdated": new Date(),
+        lastUpdated: new Date(),
+      },
+    },
+  );
+};
+
+Meteor.methods({
+  /**
+   * Start a v2 identity migration for the caller's own approved device.
+   * Returns a signing challenge (proves possession of the new private key).
+   * The separate push challenge is only ever delivered via FCM.
+   */
+  async "devices.beginIdentityMigration"(options) {
+    check(options, {
+      deviceUUID: String,
+      installationId: String,
+      publicKey: String,
+    });
+    requireLogin(this);
+
+    const { deviceUUID, installationId, publicKey } = options;
+
+    if (!asP256KeyObject(publicKey)) {
+      throw new Meteor.Error(
+        "invalid-public-key",
+        "The installation public key must be an ECDSA P-256 SPKI key.",
+      );
+    }
+
+    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+    const device = userDoc?.devices?.find((d) => d.deviceUUID === deviceUUID);
+
+    if (!device) {
+      throw new Meteor.Error("not-found", "Device not found.");
+    }
+    if (device.deviceRegistrationStatus !== "approved") {
+      throw new Meteor.Error(
+        "device-not-approved",
+        "Only approved devices can migrate.",
+      );
+    }
+    if (device.identityVersion === 2) {
+      throw new Meteor.Error(
+        "already-migrated",
+        "This device already has a v2 identity.",
+      );
+    }
+
+    // One live challenge per device — restarting invalidates older attempts.
+    await MigrationChallenges.removeAsync({ userId: this.userId, deviceUUID });
+
+    const now = new Date();
+    const challengeId = await MigrationChallenges.insertAsync({
+      userId: this.userId,
+      deviceUUID,
+      installationId,
+      publicKey,
+      signingChallenge: Random.secret(32),
+      pushChallenge: Random.secret(32),
+      createdAt: now,
+      expiresAt: new Date(now.getTime() + CHALLENGE_EXPIRY_MS),
+      usedAt: null,
+    });
+
+    const challenge = await MigrationChallenges.findOneAsync(challengeId);
+    return {
+      challengeId,
+      signingChallenge: challenge.signingChallenge,
+      expiresAt: challenge.expiresAt,
+    };
+  },
+
+  /**
+   * Prove the migration with the device-bound biometric secret plus a
+   * signature over the signing challenge by the new installation key.
+   */
+  async "devices.proveMigrationByBiometric"(options) {
+    check(options, {
+      challengeId: String,
+      biometricSecret: String,
+      signedChallenge: String,
+    });
+    requireLogin(this);
+
+    const { challengeId, biometricSecret, signedChallenge } = options;
+    const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
+
+    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+    const device = userDoc?.devices?.find(
+      (d) => d.deviceUUID === challenge.deviceUUID,
+    );
+
+    if (
+      !device?.biometricSecret ||
+      !timingSafeEquals(device.biometricSecret, biometricSecret)
+    ) {
+      throw new Meteor.Error("proof-failed", "Biometric verification failed.");
+    }
+    if (
+      !verifySignature(
+        challenge.publicKey,
+        challenge.signingChallenge,
+        signedChallenge,
+      )
+    ) {
+      throw new Meteor.Error("proof-failed", "Signature verification failed.");
+    }
+
+    await consumeChallenge(challengeId);
+    await bindIdentity(this.userId, challenge, "biometric");
+    return { success: true, migrationProof: "biometric" };
+  },
+
+  /**
+   * Deliver the push challenge to the FCM token ALREADY STORED in Mongo for
+   * the device under migration — never to a caller-supplied token. Only the
+   * physical phone holding that registration can receive it.
+   */
+  async "devices.requestMigrationPushChallenge"(options) {
+    check(options, { challengeId: String });
+    requireLogin(this);
+
+    const challenge = await getLiveChallengeOrThrow(
+      this.userId,
+      options.challengeId,
+    );
+
+    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+    const device = userDoc?.devices?.find(
+      (d) => d.deviceUUID === challenge.deviceUUID,
+    );
+
+    if (!device?.fcmToken) {
+      throw new Meteor.Error(
+        "no-stored-token",
+        "No FCM token is stored for this device — push proof is unavailable.",
+      );
+    }
+
+    // Empty title/body + isSync makes this a silent data-only push.
+    const messageId = await sendNotification(device.fcmToken, "", "", {
+      notificationType: "migration_challenge",
+      isSync: "true",
+      challengeId: options.challengeId,
+      pushChallenge: challenge.pushChallenge,
+    });
+
+    return { success: true, sent: !!messageId };
+  },
+
+  /**
+   * Prove the migration by echoing the push-delivered challenge plus a
+   * signature over the signing challenge by the new installation key.
+   */
+  async "devices.proveMigrationByPush"(options) {
+    check(options, {
+      challengeId: String,
+      pushChallenge: String,
+      signedChallenge: String,
+    });
+    requireLogin(this);
+
+    const { challengeId, pushChallenge, signedChallenge } = options;
+    const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
+
+    if (!timingSafeEquals(challenge.pushChallenge, pushChallenge)) {
+      throw new Meteor.Error("proof-failed", "Push challenge did not match.");
+    }
+    if (
+      !verifySignature(
+        challenge.publicKey,
+        challenge.signingChallenge,
+        signedChallenge,
+      )
+    ) {
+      throw new Meteor.Error("proof-failed", "Signature verification failed.");
+    }
+
+    await consumeChallenge(challengeId);
+    await bindIdentity(this.userId, challenge, "fcm-challenge");
+    return { success: true, migrationProof: "fcm-challenge" };
+  },
+});
+
+const MIGRATION_METHODS = new Set([
+  "devices.beginIdentityMigration",
+  "devices.proveMigrationByBiometric",
+  "devices.requestMigrationPushChallenge",
+  "devices.proveMigrationByPush",
+]);
+
+DDPRateLimiter.addRule(
+  {
+    type: "method",
+    name: (name) => MIGRATION_METHODS.has(name),
+    connectionId: () => true,
+  },
+  10,
+  60 * 1000,
+);

--- a/server/main.js
+++ b/server/main.js
@@ -15,6 +15,7 @@ import {
   removeUserCompletely,
   notifyApprovedDevices,
 } from "./deviceManagement.js"; // Also registers self-service device management methods + rate limiting
+import "./identityMigration.js"; // v1 -> v2 installation-identity migration methods
 import { NotificationHistory } from "../utils/api/notificationHistory.js";
 import { ApprovalTokens } from "../utils/api/approvalTokens";
 import { PendingResponses } from "../utils/api/pendingResponses.js";

--- a/tests/identityMigration.js
+++ b/tests/identityMigration.js
@@ -1,0 +1,377 @@
+import assert from "assert";
+import crypto from "crypto";
+
+if (Meteor.isServer) {
+  describe("Identity migration (v1 -> v2)", function () {
+    require("../server/identityMigration.js"); // Registers the Meteor methods
+    const { DeviceDetails } = require("../utils/api/deviceDetails");
+    const { MigrationChallenges } = require("../utils/api/migrationChallenges");
+
+    const USER_A = "identity-user-a";
+    const USER_B = "identity-user-b";
+    const BIO_SECRET = "identity-bio-secret";
+
+    const callMethod = (name, context, ...args) =>
+      Meteor.server.method_handlers[name].call(context, ...args);
+
+    // WebCrypto-equivalent keypair: P-256, SPKI DER public key, P1363 signatures.
+    const makeKeyPair = () => {
+      const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", {
+        namedCurve: "prime256v1",
+      });
+      return {
+        publicKeyB64: publicKey
+          .export({ format: "der", type: "spki" })
+          .toString("base64"),
+        sign: (message) =>
+          crypto
+            .sign("sha256", Buffer.from(message, "utf8"), {
+              key: privateKey,
+              dsaEncoding: "ieee-p1363",
+            })
+            .toString("base64"),
+      };
+    };
+
+    const beginMigration = async (keyPair, overrides = {}) =>
+      callMethod(
+        "devices.beginIdentityMigration",
+        { userId: USER_A },
+        {
+          deviceUUID: "uuid-v1",
+          installationId: "install-1",
+          publicKey: keyPair.publicKeyB64,
+          ...overrides,
+        },
+      );
+
+    beforeEach(async function () {
+      await DeviceDetails.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+      await MigrationChallenges.removeAsync({
+        userId: { $in: [USER_A, USER_B] },
+      });
+
+      await DeviceDetails.insertAsync({
+        userId: USER_A,
+        username: "identitya",
+        email: "identitya@example.com",
+        devices: [
+          {
+            deviceUUID: "uuid-v1",
+            appId: "app-v1",
+            biometricSecret: BIO_SECRET,
+            fcmToken: "fcm-v1",
+            deviceRegistrationStatus: "approved",
+            isPrimary: true,
+            lastUpdated: new Date(),
+          },
+          {
+            deviceUUID: "uuid-pending",
+            appId: "app-pending",
+            biometricSecret: "other-secret",
+            fcmToken: "fcm-pending",
+            deviceRegistrationStatus: "pending",
+            isPrimary: false,
+            lastUpdated: new Date(),
+          },
+        ],
+        createdAt: new Date(),
+        lastUpdated: new Date(),
+      });
+    });
+
+    afterEach(async function () {
+      await DeviceDetails.removeAsync({ userId: { $in: [USER_A, USER_B] } });
+      await MigrationChallenges.removeAsync({
+        userId: { $in: [USER_A, USER_B] },
+      });
+    });
+
+    describe("devices.beginIdentityMigration", function () {
+      it("rejects unauthenticated callers", async function () {
+        const keyPair = makeKeyPair();
+        await assert.rejects(
+          callMethod(
+            "devices.beginIdentityMigration",
+            { userId: null },
+            {
+              deviceUUID: "uuid-v1",
+              installationId: "install-1",
+              publicKey: keyPair.publicKeyB64,
+            },
+          ),
+          /not-authorized/,
+        );
+      });
+
+      it("rejects a malformed public key", async function () {
+        await assert.rejects(
+          beginMigration(makeKeyPair(), { publicKey: "not-a-key" }),
+          /invalid-public-key/,
+        );
+      });
+
+      it("rejects a non-P-256 public key", async function () {
+        const { publicKey } = crypto.generateKeyPairSync("rsa", {
+          modulusLength: 2048,
+        });
+        await assert.rejects(
+          beginMigration(makeKeyPair(), {
+            publicKey: publicKey
+              .export({ format: "der", type: "spki" })
+              .toString("base64"),
+          }),
+          /invalid-public-key/,
+        );
+      });
+
+      it("rejects an unapproved device", async function () {
+        await assert.rejects(
+          beginMigration(makeKeyPair(), { deviceUUID: "uuid-pending" }),
+          /device-not-approved/,
+        );
+      });
+
+      it("rejects another user's device", async function () {
+        const keyPair = makeKeyPair();
+        await assert.rejects(
+          callMethod(
+            "devices.beginIdentityMigration",
+            { userId: USER_B },
+            {
+              deviceUUID: "uuid-v1",
+              installationId: "install-x",
+              publicKey: keyPair.publicKeyB64,
+            },
+          ),
+          /not-found/,
+        );
+      });
+
+      it("returns a signing challenge but never the push challenge", async function () {
+        const result = await beginMigration(makeKeyPair());
+        assert.ok(result.challengeId);
+        assert.ok(result.signingChallenge);
+        assert.strictEqual(result.pushChallenge, undefined);
+      });
+
+      it("invalidates older challenges for the same device", async function () {
+        const first = await beginMigration(makeKeyPair());
+        await beginMigration(makeKeyPair());
+        const stale = await MigrationChallenges.findOneAsync(first.challengeId);
+        assert.strictEqual(stale, undefined);
+      });
+    });
+
+    describe("devices.proveMigrationByBiometric", function () {
+      it("binds the v2 identity on a valid proof", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+
+        const result = await callMethod(
+          "devices.proveMigrationByBiometric",
+          { userId: USER_A },
+          {
+            challengeId,
+            biometricSecret: BIO_SECRET,
+            signedChallenge: keyPair.sign(signingChallenge),
+          },
+        );
+        assert.strictEqual(result.success, true);
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-v1");
+        assert.strictEqual(device.identityVersion, 2);
+        assert.strictEqual(device.migrationProof, "biometric");
+        assert.strictEqual(device.installationId, "install-1");
+        assert.strictEqual(device.publicKey, keyPair.publicKeyB64);
+        assert.strictEqual(device.deviceRegistrationStatus, "approved");
+      });
+
+      it("rejects a wrong biometric secret and leaves state unchanged", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByBiometric",
+            { userId: USER_A },
+            {
+              challengeId,
+              biometricSecret: "wrong-secret",
+              signedChallenge: keyPair.sign(signingChallenge),
+            },
+          ),
+          /proof-failed/,
+        );
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-v1");
+        assert.strictEqual(device.identityVersion, undefined);
+      });
+
+      it("rejects a signature from a different key", async function () {
+        const keyPair = makeKeyPair();
+        const attacker = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByBiometric",
+            { userId: USER_A },
+            {
+              challengeId,
+              biometricSecret: BIO_SECRET,
+              signedChallenge: attacker.sign(signingChallenge),
+            },
+          ),
+          /proof-failed/,
+        );
+      });
+
+      it("rejects an expired challenge", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        await MigrationChallenges.updateAsync(
+          { _id: challengeId },
+          { $set: { expiresAt: new Date(Date.now() - 1000) } },
+        );
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByBiometric",
+            { userId: USER_A },
+            {
+              challengeId,
+              biometricSecret: BIO_SECRET,
+              signedChallenge: keyPair.sign(signingChallenge),
+            },
+          ),
+          /challenge-invalid/,
+        );
+      });
+
+      it("rejects a reused challenge", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        const proof = {
+          challengeId,
+          biometricSecret: BIO_SECRET,
+          signedChallenge: keyPair.sign(signingChallenge),
+        };
+
+        await callMethod(
+          "devices.proveMigrationByBiometric",
+          { userId: USER_A },
+          proof,
+        );
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByBiometric",
+            { userId: USER_A },
+            proof,
+          ),
+          /challenge-invalid/,
+        );
+      });
+
+      it("blocks a second migration of an already-migrated device", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        await callMethod(
+          "devices.proveMigrationByBiometric",
+          { userId: USER_A },
+          {
+            challengeId,
+            biometricSecret: BIO_SECRET,
+            signedChallenge: keyPair.sign(signingChallenge),
+          },
+        );
+
+        await assert.rejects(beginMigration(makeKeyPair()), /already-migrated/);
+      });
+    });
+
+    describe("devices.proveMigrationByPush", function () {
+      it("binds the v2 identity when the pushed challenge is echoed", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        // The push payload is unavailable in tests (Firebase disabled); read
+        // the value the server would have sent.
+        const challenge = await MigrationChallenges.findOneAsync(challengeId);
+
+        const result = await callMethod(
+          "devices.proveMigrationByPush",
+          { userId: USER_A },
+          {
+            challengeId,
+            pushChallenge: challenge.pushChallenge,
+            signedChallenge: keyPair.sign(signingChallenge),
+          },
+        );
+        assert.strictEqual(result.migrationProof, "fcm-challenge");
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-v1");
+        assert.strictEqual(device.identityVersion, 2);
+      });
+
+      it("rejects a wrong push challenge", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByPush",
+            { userId: USER_A },
+            {
+              challengeId,
+              pushChallenge: "guessed-value",
+              signedChallenge: keyPair.sign(signingChallenge),
+            },
+          ),
+          /proof-failed/,
+        );
+      });
+
+      it("rejects another user's challenge", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        const challenge = await MigrationChallenges.findOneAsync(challengeId);
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByPush",
+            { userId: USER_B },
+            {
+              challengeId,
+              pushChallenge: challenge.pushChallenge,
+              signedChallenge: keyPair.sign(signingChallenge),
+            },
+          ),
+          /challenge-invalid/,
+        );
+      });
+    });
+
+    describe("devices.requestMigrationPushChallenge", function () {
+      it("refuses when the device has no stored FCM token", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId } = await beginMigration(keyPair);
+        await DeviceDetails.updateAsync(
+          { userId: USER_A, "devices.deviceUUID": "uuid-v1" },
+          { $unset: { "devices.$.fcmToken": "" } },
+        );
+
+        await assert.rejects(
+          callMethod(
+            "devices.requestMigrationPushChallenge",
+            { userId: USER_A },
+            { challengeId },
+          ),
+          /no-stored-token/,
+        );
+      });
+    });
+  });
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -2,6 +2,7 @@ import assert from "assert";
 import "./duo.js";
 import "./healthcheck.js";
 import "./deviceManagement.js";
+import "./identityMigration.js";
 
 describe("meteor-app", function () {
   it("package.json has correct name", async function () {

--- a/utils/api/migrationChallenges.js
+++ b/utils/api/migrationChallenges.js
@@ -1,0 +1,27 @@
+import { Mongo } from "meteor/mongo";
+
+// Short-lived, single-use challenges for the v1 -> v2 installation-identity
+// migration (see migration-plan.md Phase 1).
+//
+// Two independent secrets per challenge:
+//  - signingChallenge: returned to the caller by devices.beginIdentityMigration;
+//    signing it proves possession of the new installation private key.
+//  - pushChallenge: NEVER returned over DDP — only delivered via FCM to the
+//    token already stored in Mongo, so echoing it proves possession of the
+//    previously registered device.
+export const MigrationChallenges = new Mongo.Collection("migrationChallenges");
+
+if (Meteor.isServer) {
+  Meteor.startup(() => {
+    try {
+      // Mongo TTL removes expired challenges automatically.
+      MigrationChallenges.createIndex(
+        { expiresAt: 1 },
+        { expireAfterSeconds: 0 },
+      );
+      MigrationChallenges.createIndex({ userId: 1, deviceUUID: 1 });
+    } catch (error) {
+      console.error("Error creating MigrationChallenges indexes:", error);
+    }
+  });
+}


### PR DESCRIPTION
Closes #452. Part of the device identity migration (migration-plan.md); stacked on #451.

## What

Server-side foundation for the non-migrating "v2 installation identity" — so device trust stops depending on `device.uuid`, which survives iCloud/Android backup restores onto replacement phones.

## Design

Each migration challenge carries **two independent secrets**:

- `signingChallenge` — returned to the caller; signing it proves possession of the new installation private key.
- `pushChallenge` — **never returned over DDP**; only delivered via FCM to the token **already stored in Mongo**, so echoing it proves possession of the previously registered physical device.

Signature scheme: ECDSA P-256 / SHA-256 / IEEE P1363 (exactly what WebCrypto produces), public keys as base64 SPKI DER, verified with Node `crypto.verify`.

## Methods (all authenticated, owner-scoped, rate-limited)

| Method | Purpose |
|---|---|
| `devices.beginIdentityMigration` | Approved v1 device starts migration; challenge TTL 5 min, one live challenge per device |
| `devices.proveMigrationByBiometric` | Timing-safe biometric compare + key signature → binds identity (`migrationProof: biometric`) |
| `devices.requestMigrationPushChallenge` | Silent data-only push of the challenge to the stored token |
| `devices.proveMigrationByPush` | Challenge echo + key signature → binds identity (`migrationProof: fcm-challenge`) |

## Invariants

- Additive only — zero behavior change for existing devices.
- Never downgrades approval; failed proofs leave state unchanged.
- Challenges are single-use (guarded consume), short-lived (Mongo TTL), and scoped to the calling user.
- Restored-from-backup phones (no biometric secret, new FCM token) cannot pass either proof.

## Tests

17 new mocha tests: both happy paths, wrong secret/signature/push value, expired + reused challenges, cross-user attempts, non-P-256/malformed keys, unapproved device, missing stored token, challenge-invalidation on restart.
