### PR TITLE
Identity migration Phase 2: client keypair + silent migration (closes #453)

### DIFF
--- a/client/main.jsx
+++ b/client/main.jsx
@@ -9,6 +9,7 @@ import { initializeBiometrics } from "./mobile/biometrics";
 import { initializeDeepLinks } from "./mobile/deep-links";
 import { initializePushNotifications } from "./mobile/push-notifications";
 import { checkNotificationPermission } from "./mobile/notification-permissions";
+import { initializeIdentityMigration } from "./mobile/identity-migration";
 import { initializeDiagnostics } from "./mobile/diagnostics";
 
 // During a hot code push the WebView is fully reloaded while the new bundle
@@ -41,6 +42,7 @@ Meteor.startup(() => {
         initializeBiometrics();
         initializeDeepLinks();
         initializePushNotifications();
+        initializeIdentityMigration();
         initializeDiagnostics();
         // Record whether the OS-level notification permission is granted so the
         // UI can prompt the user to re-enable it if they denied/dismissed it.

--- a/client/mobile/identity-migration.js
+++ b/client/mobile/identity-migration.js
@@ -1,0 +1,122 @@
+import { Meteor } from "meteor/meteor";
+import { Session } from "meteor/session";
+import { Tracker } from "meteor/tracker";
+import { getOrCreateIdentity } from "./installation-identity";
+
+// Silent v1 -> v2 identity migration (migration-plan.md Phase 2).
+//
+// Never blocks the UI and never surfaces errors to the user; devices that
+// cannot be proven silently stay v1 until the Phase 4 fallback UX.
+
+// Challenge awaiting its push-delivered proof for this launch.
+let pendingPushMigration = null;
+// At most one automatic attempt per app launch.
+let attemptedThisLaunch = false;
+
+const begin = async (identity, deviceUUID) =>
+  Meteor.callAsync("devices.beginIdentityMigration", {
+    deviceUUID,
+    installationId: identity.installationId,
+    publicKey: identity.publicKeyB64,
+  });
+
+const isExpectedHalt = (error) =>
+  [
+    "already-migrated",
+    "device-not-approved",
+    "not-found",
+    "challenge-invalid",
+  ].includes(error?.error);
+
+/**
+ * Fast path: called right after a successful biometric login, when the
+ * device-bound secret is already in hand — no extra prompt, no push needed.
+ */
+export const migrateWithBiometricSecret = async (biometricSecret) => {
+  try {
+    const deviceUUID = Session.get("capturedDeviceInfo")?.uuid;
+    if (!deviceUUID) return;
+
+    // Claim this launch's attempt so the background push path doesn't race
+    // and invalidate our challenge mid-proof.
+    attemptedThisLaunch = true;
+
+    const identity = await getOrCreateIdentity();
+    const { challengeId, signingChallenge } = await begin(identity, deviceUUID);
+
+    await Meteor.callAsync("devices.proveMigrationByBiometric", {
+      challengeId,
+      biometricSecret,
+      signedChallenge: await identity.sign(signingChallenge),
+    });
+    console.log("[IdentityMigration] migrated via biometric proof");
+  } catch (error) {
+    if (!isExpectedHalt(error)) {
+      console.warn("[IdentityMigration] biometric path failed:", error.reason);
+    }
+  }
+};
+
+/**
+ * Completes a migration when the server's challenge arrives via FCM (sent to
+ * the token stored in Mongo — receiving it proves this is the registered
+ * physical device). Called from the push notification handler.
+ */
+export const completePushMigration = async (additionalData) => {
+  const { challengeId, pushChallenge } = additionalData || {};
+  if (!challengeId || !pushChallenge || !pendingPushMigration) return;
+  if (pendingPushMigration.challengeId !== challengeId) return;
+
+  try {
+    await Meteor.callAsync("devices.proveMigrationByPush", {
+      challengeId,
+      pushChallenge,
+      signedChallenge: await pendingPushMigration.identity.sign(
+        pendingPushMigration.signingChallenge,
+      ),
+    });
+    console.log("[IdentityMigration] migrated via push-challenge proof");
+  } catch (error) {
+    if (!isExpectedHalt(error)) {
+      console.warn("[IdentityMigration] push proof failed:", error.reason);
+    }
+  } finally {
+    pendingPushMigration = null;
+  }
+};
+
+/**
+ * Background path: once logged in with device info available, start a
+ * migration and ask the server to push the challenge to the stored token.
+ */
+export const initializeIdentityMigration = () => {
+  Tracker.autorun(async (computation) => {
+    const userId = Meteor.userId();
+    const deviceUUID = Session.get("capturedDeviceInfo")?.uuid;
+    if (!userId || !deviceUUID || attemptedThisLaunch) return;
+
+    computation.stop();
+    attemptedThisLaunch = true;
+
+    try {
+      const identity = await getOrCreateIdentity();
+      const { challengeId, signingChallenge } = await begin(
+        identity,
+        deviceUUID,
+      );
+
+      pendingPushMigration = { challengeId, signingChallenge, identity };
+      await Meteor.callAsync("devices.requestMigrationPushChallenge", {
+        challengeId,
+      });
+    } catch (error) {
+      pendingPushMigration = null;
+      if (!isExpectedHalt(error)) {
+        console.warn(
+          "[IdentityMigration] background path failed:",
+          error.reason,
+        );
+      }
+    }
+  });
+};

--- a/client/mobile/installation-identity.js
+++ b/client/mobile/installation-identity.js
@@ -1,0 +1,93 @@
+// Non-migrating installation identity (migration-plan.md Phase 2).
+//
+// An ECDSA P-256 keypair generated on this installation. The private key is
+// non-extractable: IndexedDB stores the CryptoKey handle, so key material is
+// never exposed to JS, localStorage, or the Meteor bundle.
+//
+// STORAGE GUARANTEE (documented per plan): WebView IndexedDB is excluded from
+// iCloud/Android cloud backups on current OS versions, but this is weaker
+// than a Keychain kSecAttrAccessible...ThisDeviceOnly item. Upgrading storage
+// to a secure-storage Cordova plugin is tracked in migration-plan.md Phase 0.
+
+const DB_NAME = "mieauth-identity";
+const STORE = "identity";
+const KEY_ID = "installation-identity-v1";
+
+const openDb = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const idbGet = async (db) =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, "readonly");
+    const request = tx.objectStore(STORE).get(KEY_ID);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const idbPut = async (db, value) =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, "readwrite");
+    const request = tx.objectStore(STORE).put(value, KEY_ID);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+
+const bufferToBase64 = (buffer) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+};
+
+const generateIdentity = async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    false, // non-extractable private key
+    ["sign", "verify"],
+  );
+  const spki = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  return {
+    installationId: crypto.randomUUID(),
+    publicKeyB64: bufferToBase64(spki),
+    privateKey: keyPair.privateKey,
+    createdAt: new Date(),
+  };
+};
+
+/**
+ * Load or create this installation's identity.
+ * @returns {Promise<{installationId: string, publicKeyB64: string, sign: (message: string) => Promise<string>}>}
+ */
+export const getOrCreateIdentity = async () => {
+  const db = await openDb();
+  let record = await idbGet(db);
+  if (!record?.privateKey) {
+    record = await generateIdentity();
+    await idbPut(db, record);
+  }
+  db.close();
+
+  return {
+    installationId: record.installationId,
+    publicKeyB64: record.publicKeyB64,
+    // Server verifies with SHA-256 over the UTF-8 message, P1363 encoding —
+    // exactly what WebCrypto ECDSA produces.
+    sign: async (message) => {
+      const signature = await crypto.subtle.sign(
+        { name: "ECDSA", hash: "SHA-256" },
+        record.privateKey,
+        new TextEncoder().encode(message),
+      );
+      return bufferToBase64(signature);
+    },
+  };
+};

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -2,6 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { IOS_APPROVAL_CATEGORIES } from "../../utils/constants.js";
+import { completePushMigration } from "./identity-migration.js";
 
 // Session validation with retry logic
 const validateSessionWithRetry = (callback, retries = 3, interval = 1000) => {
@@ -222,6 +223,12 @@ const setupNotificationHandler = (push) => {
   push.on("notification", (notification) => {
     Meteor.startup(() => {
       const additionalData = notification.additionalData || {};
+
+      // Data-only identity-migration challenge — handled silently, no UI.
+      if (additionalData.notificationType === "migration_challenge") {
+        completePushMigration(additionalData);
+        return;
+      }
 
       // Skip if action was already handled from the notification tray. Do NOT
       // clear the flag here — the tray-action request may still be in flight,

--- a/client/mobile/src/ui/Login.jsx
+++ b/client/mobile/src/ui/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { openSupportLink } from "../../../../utils/openExternal";
+import { migrateWithBiometricSecret } from "../../identity-migration";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Random } from "meteor/random";
@@ -227,6 +228,9 @@ export const LoginPage = ({ deviceDetails }) => {
                   username: result.username,
                   _id: result._id,
                 });
+                // Fire-and-forget: the device-bound secret is already in hand,
+                // so upgrade this installation to a v2 identity silently.
+                migrateWithBiometricSecret(biometricSecret);
                 navigate("/dashboard");
               } else {
                 await new Promise((res) => Meteor.logout(res));


### PR DESCRIPTION
Closes #453. Stacked on the Phase 1 PR (feat/identity-migration-server).

## What

Client side of the v2 installation identity: keypair generation and fully silent migration of approved v1 devices on launch.

## How

- `client/mobile/installation-identity.js` — ECDSA P-256 keypair via WebCrypto with a **non-extractable** private key; the CryptoKey handle is persisted in IndexedDB so key material is never exposed to JS. The storage guarantee (weaker than Keychain `ThisDeviceOnly`) is documented in the module; the secure-storage plugin upgrade remains tracked in migration-plan.md Phase 0.
- `client/mobile/identity-migration.js`:
  - **Biometric fast path** — invoked right after a successful biometric login, when the device-bound secret is already in hand: begin → prove → done. No extra prompt.
  - **Background push path** — reactive on login + captured device info: begin → server pushes the challenge to the stored FCM token → data-only push handler completes the proof.
  - One attempt per launch, never blocks UI, expected halts (`already-migrated`, `device-not-approved`, `challenge-invalid`, `not-found`) stay silent.
- Push handler gains a silent `migration_challenge` branch (no banner/modal).

## Invariants

- A phone restored from a cloud backup has neither the biometric secret nor the old FCM registration — it cannot migrate silently and stays v1 until the Phase 4 fallback.
- Migration failure changes nothing server-side and shows nothing to the user.
