### PR TITLE
Identity migration Phase 3: rollout observability (closes #454)

### DIFF
--- a/server/adminApi.js
+++ b/server/adminApi.js
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import { ApiKeys } from "../utils/api/apiKeys";
 import { DeviceDetails } from "../utils/api/deviceDetails";
 import { EmailLog } from "../utils/api/emailLog";
+import { MigrationEvents } from "../utils/api/migrationEvents";
 import { NotificationHistory } from "../utils/api/notificationHistory";
 import { sendNotification } from "./firebase";
 import {
@@ -1007,6 +1008,105 @@ WebApp.connectHandlers.use(
               : `FCM rejected the message: ${fcmErr.message}`,
           });
         }
+      } catch (err) {
+        const mapped = mapMeteorError(err);
+        sendJson(res, mapped.status, {
+          error: mapped.error,
+          errorCode: mapped.errorCode,
+        });
+      }
+    });
+  },
+);
+
+// Rollout coverage for the v1 -> v2 identity migration (migration-plan.md
+// Phase 3): device counts per identity version / proof, and recent failures.
+WebApp.connectHandlers.use(
+  "/api/admin/diagnostics/identity-migration",
+  async (req, res) => {
+    setCors(res);
+    if (req.method === "OPTIONS") {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    if (req.method !== "GET")
+      return sendJson(res, 405, { error: "Method not allowed" });
+
+    await requireAdminAuth(req, res, async () => {
+      try {
+        const THIRTY_DAYS_AGO = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+        const [stats] = await DeviceDetails.rawCollection()
+          .aggregate([
+            { $unwind: "$devices" },
+            {
+              $group: {
+                _id: null,
+                total: { $sum: 1 },
+                v2: {
+                  $sum: {
+                    $cond: [{ $eq: ["$devices.identityVersion", 2] }, 1, 0],
+                  },
+                },
+                v2ActiveLast30d: {
+                  $sum: {
+                    $cond: [
+                      {
+                        $and: [
+                          { $eq: ["$devices.identityVersion", 2] },
+                          { $gte: ["$devices.lastUsed", THIRTY_DAYS_AGO] },
+                        ],
+                      },
+                      1,
+                      0,
+                    ],
+                  },
+                },
+                activeLast30d: {
+                  $sum: {
+                    $cond: [
+                      { $gte: ["$devices.lastUsed", THIRTY_DAYS_AGO] },
+                      1,
+                      0,
+                    ],
+                  },
+                },
+                byProof: { $push: "$devices.migrationProof" },
+              },
+            },
+          ])
+          .toArray();
+
+        const proofCounts = {};
+        (stats?.byProof || []).forEach((proof) => {
+          if (proof) proofCounts[proof] = (proofCounts[proof] || 0) + 1;
+        });
+
+        const recentFailures = await MigrationEvents.find(
+          { outcome: { $ne: "success" } },
+          { sort: { createdAt: -1 }, limit: 20 },
+        ).fetchAsync();
+
+        sendJson(res, 200, {
+          success: true,
+          devices: {
+            total: stats?.total || 0,
+            v2: stats?.v2 || 0,
+            v1: (stats?.total || 0) - (stats?.v2 || 0),
+            activeLast30d: stats?.activeLast30d || 0,
+            v2ActiveLast30d: stats?.v2ActiveLast30d || 0,
+            byProof: proofCounts,
+          },
+          recentFailures: recentFailures.map((event) => ({
+            action: event.action,
+            outcome: event.outcome,
+            message: event.message,
+            userId: event.userId,
+            deviceUUID: event.deviceUUID,
+            createdAt: event.createdAt,
+          })),
+        });
       } catch (err) {
         const mapped = mapMeteorError(err);
         sendJson(res, mapped.status, {

--- a/server/identityMigration.js
+++ b/server/identityMigration.js
@@ -5,6 +5,7 @@ import { Random } from "meteor/random";
 import crypto from "crypto";
 import { DeviceDetails } from "../utils/api/deviceDetails.js";
 import { MigrationChallenges } from "../utils/api/migrationChallenges.js";
+import { logMigrationEvent } from "../utils/api/migrationEvents.js";
 import { timingSafeEquals } from "./deviceManagement.js";
 import { sendNotification } from "./firebase.js";
 
@@ -109,13 +110,38 @@ const bindIdentity = async (userId, challenge, migrationProof) => {
   );
 };
 
+// Rollout observability (Phase 3): record every attempt's outcome so admins
+// can measure v2 coverage and fix recurring failures before enforcement.
+const logged = (action, handler) =>
+  async function (options) {
+    try {
+      const result = await handler.call(this, options);
+      logMigrationEvent({
+        action,
+        userId: this.userId,
+        deviceUUID: options?.deviceUUID,
+        outcome: "success",
+      });
+      return result;
+    } catch (error) {
+      logMigrationEvent({
+        action,
+        userId: this.userId,
+        deviceUUID: options?.deviceUUID,
+        outcome: error.error || "error",
+        message: error.reason || error.message,
+      });
+      throw error;
+    }
+  };
+
 Meteor.methods({
   /**
    * Start a v2 identity migration for the caller's own approved device.
    * Returns a signing challenge (proves possession of the new private key).
    * The separate push challenge is only ever delivered via FCM.
    */
-  async "devices.beginIdentityMigration"(options) {
+  "devices.beginIdentityMigration": logged("begin", async function (options) {
     check(options, {
       deviceUUID: String,
       installationId: String,
@@ -173,118 +199,136 @@ Meteor.methods({
       signingChallenge: challenge.signingChallenge,
       expiresAt: challenge.expiresAt,
     };
-  },
+  }),
 
   /**
    * Prove the migration with the device-bound biometric secret plus a
    * signature over the signing challenge by the new installation key.
    */
-  async "devices.proveMigrationByBiometric"(options) {
-    check(options, {
-      challengeId: String,
-      biometricSecret: String,
-      signedChallenge: String,
-    });
-    requireLogin(this);
+  "devices.proveMigrationByBiometric": logged(
+    "prove-biometric",
+    async function (options) {
+      check(options, {
+        challengeId: String,
+        biometricSecret: String,
+        signedChallenge: String,
+      });
+      requireLogin(this);
 
-    const { challengeId, biometricSecret, signedChallenge } = options;
-    const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
+      const { challengeId, biometricSecret, signedChallenge } = options;
+      const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
 
-    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
-    const device = userDoc?.devices?.find(
-      (d) => d.deviceUUID === challenge.deviceUUID,
-    );
+      const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+      const device = userDoc?.devices?.find(
+        (d) => d.deviceUUID === challenge.deviceUUID,
+      );
 
-    if (
-      !device?.biometricSecret ||
-      !timingSafeEquals(device.biometricSecret, biometricSecret)
-    ) {
-      throw new Meteor.Error("proof-failed", "Biometric verification failed.");
-    }
-    if (
-      !verifySignature(
-        challenge.publicKey,
-        challenge.signingChallenge,
-        signedChallenge,
-      )
-    ) {
-      throw new Meteor.Error("proof-failed", "Signature verification failed.");
-    }
+      if (
+        !device?.biometricSecret ||
+        !timingSafeEquals(device.biometricSecret, biometricSecret)
+      ) {
+        throw new Meteor.Error(
+          "proof-failed",
+          "Biometric verification failed.",
+        );
+      }
+      if (
+        !verifySignature(
+          challenge.publicKey,
+          challenge.signingChallenge,
+          signedChallenge,
+        )
+      ) {
+        throw new Meteor.Error(
+          "proof-failed",
+          "Signature verification failed.",
+        );
+      }
 
-    await consumeChallenge(challengeId);
-    await bindIdentity(this.userId, challenge, "biometric");
-    return { success: true, migrationProof: "biometric" };
-  },
+      await consumeChallenge(challengeId);
+      await bindIdentity(this.userId, challenge, "biometric");
+      return { success: true, migrationProof: "biometric" };
+    },
+  ),
 
   /**
    * Deliver the push challenge to the FCM token ALREADY STORED in Mongo for
    * the device under migration — never to a caller-supplied token. Only the
    * physical phone holding that registration can receive it.
    */
-  async "devices.requestMigrationPushChallenge"(options) {
-    check(options, { challengeId: String });
-    requireLogin(this);
+  "devices.requestMigrationPushChallenge": logged(
+    "request-push",
+    async function (options) {
+      check(options, { challengeId: String });
+      requireLogin(this);
 
-    const challenge = await getLiveChallengeOrThrow(
-      this.userId,
-      options.challengeId,
-    );
-
-    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
-    const device = userDoc?.devices?.find(
-      (d) => d.deviceUUID === challenge.deviceUUID,
-    );
-
-    if (!device?.fcmToken) {
-      throw new Meteor.Error(
-        "no-stored-token",
-        "No FCM token is stored for this device — push proof is unavailable.",
+      const challenge = await getLiveChallengeOrThrow(
+        this.userId,
+        options.challengeId,
       );
-    }
 
-    // Empty title/body + isSync makes this a silent data-only push.
-    const messageId = await sendNotification(device.fcmToken, "", "", {
-      notificationType: "migration_challenge",
-      isSync: "true",
-      challengeId: options.challengeId,
-      pushChallenge: challenge.pushChallenge,
-    });
+      const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+      const device = userDoc?.devices?.find(
+        (d) => d.deviceUUID === challenge.deviceUUID,
+      );
 
-    return { success: true, sent: !!messageId };
-  },
+      if (!device?.fcmToken) {
+        throw new Meteor.Error(
+          "no-stored-token",
+          "No FCM token is stored for this device — push proof is unavailable.",
+        );
+      }
+
+      // Empty title/body + isSync makes this a silent data-only push.
+      const messageId = await sendNotification(device.fcmToken, "", "", {
+        notificationType: "migration_challenge",
+        isSync: "true",
+        challengeId: options.challengeId,
+        pushChallenge: challenge.pushChallenge,
+      });
+
+      return { success: true, sent: !!messageId };
+    },
+  ),
 
   /**
    * Prove the migration by echoing the push-delivered challenge plus a
    * signature over the signing challenge by the new installation key.
    */
-  async "devices.proveMigrationByPush"(options) {
-    check(options, {
-      challengeId: String,
-      pushChallenge: String,
-      signedChallenge: String,
-    });
-    requireLogin(this);
+  "devices.proveMigrationByPush": logged(
+    "prove-push",
+    async function (options) {
+      check(options, {
+        challengeId: String,
+        pushChallenge: String,
+        signedChallenge: String,
+      });
+      requireLogin(this);
 
-    const { challengeId, pushChallenge, signedChallenge } = options;
-    const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
+      const { challengeId, pushChallenge, signedChallenge } = options;
+      const challenge = await getLiveChallengeOrThrow(this.userId, challengeId);
 
-    if (!timingSafeEquals(challenge.pushChallenge, pushChallenge)) {
-      throw new Meteor.Error("proof-failed", "Push challenge did not match.");
-    }
-    if (
-      !verifySignature(
-        challenge.publicKey,
-        challenge.signingChallenge,
-        signedChallenge,
-      )
-    ) {
-      throw new Meteor.Error("proof-failed", "Signature verification failed.");
-    }
+      if (!timingSafeEquals(challenge.pushChallenge, pushChallenge)) {
+        throw new Meteor.Error("proof-failed", "Push challenge did not match.");
+      }
+      if (
+        !verifySignature(
+          challenge.publicKey,
+          challenge.signingChallenge,
+          signedChallenge,
+        )
+      ) {
+        throw new Meteor.Error(
+          "proof-failed",
+          "Signature verification failed.",
+        );
+      }
 
-    await consumeChallenge(challengeId);
-    await bindIdentity(this.userId, challenge, "fcm-challenge");
-    return { success: true, migrationProof: "fcm-challenge" };
-  },
+      await consumeChallenge(challengeId);
+      await bindIdentity(this.userId, challenge, "fcm-challenge");
+      return { success: true, migrationProof: "fcm-challenge" };
+    },
+  ),
 });
 
 const MIGRATION_METHODS = new Set([

--- a/server/templates/admin.js
+++ b/server/templates/admin.js
@@ -774,6 +774,13 @@ const DiagnosticsTab = ({ toast, toastErr }) => {
   const [notFound, setNotFound] = useState(false);
   const [pushResults, setPushResults] = useState({});
   const [pushing, setPushing] = useState(null);
+  const [migration, setMigration] = useState(null);
+
+  useEffect(() => {
+    api('/api/admin/diagnostics/identity-migration')
+      .then(res => { if (res.success) setMigration(res); })
+      .catch(() => {});
+  }, []);
 
   const lookup = async (e) => {
     if (e) e.preventDefault();
@@ -811,6 +818,30 @@ const DiagnosticsTab = ({ toast, toastErr }) => {
 
   return (
     <div className="space-y-6 fade-in">
+      {/* Identity migration rollout coverage */}
+      {migration && (
+        <div className="bg-white rounded-xl shadow-sm border p-5">
+          <h3 className="font-semibold text-gray-900 mb-1">Identity Migration (v1 → v2)</h3>
+          <p className="text-xs text-gray-500 mb-3">Coverage of the installation-identity rollout. Enforcement (Phase 5) requires &gt;90% of devices active in the last 30 days to be v2.</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+            <div className="bg-gray-50 rounded-lg p-3"><p className="text-xs text-gray-500">Devices (total)</p><p className="font-semibold text-lg">{migration.devices.total}</p></div>
+            <div className="bg-gray-50 rounded-lg p-3"><p className="text-xs text-gray-500">v2 migrated</p><p className="font-semibold text-lg">{migration.devices.v2} <span className="text-xs text-gray-400">/ {migration.devices.v1} still v1</span></p></div>
+            <div className="bg-gray-50 rounded-lg p-3"><p className="text-xs text-gray-500">30-day-active coverage</p><p className="font-semibold text-lg">{migration.devices.activeLast30d ? Math.round(100 * migration.devices.v2ActiveLast30d / migration.devices.activeLast30d) : 0}%</p></div>
+            <div className="bg-gray-50 rounded-lg p-3"><p className="text-xs text-gray-500">By proof</p><p className="text-xs">{Object.entries(migration.devices.byProof).map(([k, v]) => k + ': ' + v).join(' · ') || '—'}</p></div>
+          </div>
+          {migration.recentFailures.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-semibold text-gray-700 mb-1">Recent failures</p>
+              <ul className="text-xs text-gray-600 space-y-0.5">
+                {migration.recentFailures.slice(0, 5).map((f, i) => (
+                  <li key={i}><code className="bg-gray-100 px-1 rounded">{f.action}</code> → {f.outcome}{f.message ? ' — ' + f.message : ''} <span className="text-gray-400">({new Date(f.createdAt).toLocaleString()})</span></li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Search */}
       <div className="bg-white rounded-xl shadow-sm border p-5">
         <h3 className="font-semibold text-gray-900 mb-1">User Diagnostics</h3>

--- a/tests/identityMigration.js
+++ b/tests/identityMigration.js
@@ -373,5 +373,44 @@ if (Meteor.isServer) {
         );
       });
     });
+
+    describe("migration event logging", function () {
+      const { MigrationEvents } = require("../utils/api/migrationEvents");
+
+      // logMigrationEvent is fire-and-forget; give the insert a beat to land.
+      const waitForEvents = () => new Promise((r) => setTimeout(r, 50));
+
+      afterEach(async function () {
+        await MigrationEvents.removeAsync({
+          userId: { $in: [USER_A, USER_B] },
+        });
+      });
+
+      it("records successful and failed attempts", async function () {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+
+        await assert.rejects(
+          callMethod(
+            "devices.proveMigrationByBiometric",
+            { userId: USER_A },
+            {
+              challengeId,
+              biometricSecret: "wrong-secret",
+              signedChallenge: keyPair.sign(signingChallenge),
+            },
+          ),
+          /proof-failed/,
+        );
+        await waitForEvents();
+
+        const events = await MigrationEvents.find({
+          userId: USER_A,
+        }).fetchAsync();
+        const outcomes = events.map((e) => `${e.action}:${e.outcome}`);
+        assert.ok(outcomes.includes("begin:success"));
+        assert.ok(outcomes.includes("prove-biometric:proof-failed"));
+      });
+    });
   });
 }

--- a/utils/api/migrationEvents.js
+++ b/utils/api/migrationEvents.js
@@ -1,0 +1,30 @@
+import { Mongo } from "meteor/mongo";
+
+// Observation log for the v1 -> v2 identity migration rollout
+// (migration-plan.md Phase 3). One document per begin/prove attempt, so
+// admins can measure coverage and diagnose recurring silent-migration
+// failures before enforcement (Phase 5).
+export const MigrationEvents = new Mongo.Collection("migrationEvents");
+
+const EVENT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+if (Meteor.isServer) {
+  Meteor.startup(() => {
+    try {
+      MigrationEvents.createIndex(
+        { createdAt: 1 },
+        { expireAfterSeconds: EVENT_TTL_SECONDS },
+      );
+      MigrationEvents.createIndex({ outcome: 1, createdAt: -1 });
+    } catch (error) {
+      console.error("Error creating MigrationEvents indexes:", error);
+    }
+  });
+}
+
+/** Fire-and-forget insert — observability must never break a migration. */
+export const logMigrationEvent = (event) => {
+  MigrationEvents.insertAsync({ ...event, createdAt: new Date() }).catch(
+    (error) => console.error("Failed to log migration event:", error),
+  );
+};


### PR DESCRIPTION
Closes #454. Stacked on the Phase 2 PR (feat/identity-migration-client).

## What

Observability for the migration rollout, feeding the >90% coverage gate that Phase 5 enforcement depends on.

- `MigrationEvents` collection (30-day TTL) — one record per begin/prove attempt with outcome and error message; fire-and-forget inserts so logging can never break a migration.
- `GET /api/admin/diagnostics/identity-migration` (admin-authenticated) — aggregate device counts: total, v1 vs v2, 30-day-active coverage percentage, per-proof breakdown, plus the 20 most recent failures.
- Admin dashboard Diagnostics tab — coverage card showing the counters against the Phase 5 gate and the most recent failure reasons.

## Tests

Event capture test (success + failure outcomes recorded per action).
