### PR TITLE
Identity migration Phase 4: fallback UX + Mark as lost (closes #455)

### DIFF
--- a/client/mobile/src/ui/DeviceManagementPage.jsx
+++ b/client/mobile/src/ui/DeviceManagementPage.jsx
@@ -8,6 +8,7 @@ import {
   Check,
   Fingerprint as FingerprintIcon,
   Pencil,
+  ShieldAlert,
   ShieldCheck,
   Smartphone,
   Star,
@@ -386,22 +387,38 @@ const DeviceManagementPage = () => {
     });
   };
 
-  const requestRevoke = (device, name) => {
+  const requestRevoke = (device, name, lost = false) => {
     const isCurrent = device.deviceUUID === currentUuid;
     const isLast = devices.length === 1;
     setActionError("");
     setPendingAction({
       type: "revoke",
+      lost,
       device,
-      title: `Remove "${name}"?`,
-      description:
-        "This device will no longer receive authentication requests and will be signed out.",
+      title: lost ? `Mark "${name}" as lost?` : `Remove "${name}"?`,
+      description: lost
+        ? "The lost device will be signed out everywhere, stop receiving authentication requests, and be removed from your account."
+        : "This device will no longer receive authentication requests and will be signed out.",
       warning: isLast
         ? "This is your only device. Removing it deregisters your account entirely — you will need to register again and be re-approved by an administrator."
         : isCurrent
           ? "You are removing the device you are currently using. You will be signed out immediately."
           : "Your other devices will be signed out and will need to sign in again.",
-      confirmLabel: "Remove device",
+      confirmLabel: lost ? "Mark as lost" : "Remove device",
+    });
+  };
+
+  const requestVerifyIdentity = (device, name) => {
+    setActionError("");
+    setPendingAction({
+      type: "verifyIdentity",
+      device,
+      title: `Verify "${name}"?`,
+      description:
+        "Confirms that installation as trusted after it couldn't be verified automatically (for example after a phone restore). Open the app on that device first, then confirm here within a few minutes.",
+      warning:
+        "Only verify a device you recognize and control. If you don't recognize it, remove it instead.",
+      confirmLabel: "Verify device",
     });
   };
 
@@ -431,6 +448,7 @@ const DeviceManagementPage = () => {
           deviceUUID: pendingAction.device.deviceUUID,
           actorDeviceUUID: currentUuid,
           reAuth,
+          lost: !!pendingAction.lost,
         });
         if (
           result.accountRemoved ||
@@ -453,6 +471,12 @@ const DeviceManagementPage = () => {
           message:
             "Primary device updated. A confirmation notification arrives in ~10s — close or background the app to see it.",
           timestamp: new Date().getTime(),
+        });
+      } else if (pendingAction.type === "verifyIdentity") {
+        await Meteor.callAsync("devices.approveIdentityMigration", {
+          deviceUUID: pendingAction.device.deviceUUID,
+          actorDeviceUUID: currentUuid,
+          reAuth,
         });
       } else {
         await Meteor.callAsync("devices.approvePending", {
@@ -667,6 +691,22 @@ const DeviceManagementPage = () => {
                         </Button>
                       )
                     )}
+                    {/* Phase 4 fallback: an approved device whose installation
+                        identity is still unverified (e.g. restored from a
+                        backup) can be vouched for from another device. */}
+                    {isApproved &&
+                      device.identityVersion !== 2 &&
+                      !isCurrent && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={!currentUuid}
+                          onClick={() => requestVerifyIdentity(device, name)}
+                        >
+                          <ShieldCheck className="h-4 w-4 mr-1.5" />
+                          Verify
+                        </Button>
+                      )}
                     {/* The primary (or only approved) device can never be
                         removed — the account always keeps one trusted device.
                         Transfer the primary role first (approved on the
@@ -681,6 +721,18 @@ const DeviceManagementPage = () => {
                       >
                         <Trash2 className="h-4 w-4 mr-1.5" />
                         Remove
+                      </Button>
+                    )}
+                    {!isEffectivePrimary && !isCurrent && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-destructive"
+                        disabled={!currentUuid}
+                        onClick={() => requestRevoke(device, name, true)}
+                      >
+                        <ShieldAlert className="h-4 w-4 mr-1.5" />
+                        Lost
                       </Button>
                     )}
                   </div>

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -76,7 +76,7 @@ const requireLogin = (context) => {
  * Accepts either the device-bound biometric secret of one of the caller's
  * approved devices, or the account PIN.
  */
-const verifyStepUpAuth = async (userId, reAuth) => {
+export const verifyStepUpAuth = async (userId, reAuth) => {
   if (reAuth.biometricSecret) {
     const userDoc = await DeviceDetails.findOneAsync({ userId });
     const verified = (userDoc?.devices || []).some(
@@ -532,10 +532,11 @@ Meteor.methods({
    * the whole account (re-registration then goes through the normal
    * first-device admin approval flow).
    */
-  async "devices.revoke"({ deviceUUID, actorDeviceUUID, reAuth }) {
+  async "devices.revoke"({ deviceUUID, actorDeviceUUID, reAuth, lost }) {
     check(deviceUUID, String);
     check(actorDeviceUUID, String);
     check(reAuth, REAUTH_PATTERN);
+    check(lost, Match.Maybe(Boolean));
     requireLogin(this);
 
     await verifyStepUpAuth(this.userId, reAuth);
@@ -580,7 +581,7 @@ Meteor.methods({
       const result = await removeUserCompletely(this.userId);
       await logDeviceAudit({
         userId: this.userId,
-        action: "revoke",
+        action: lost ? "markLost" : "revoke",
         deviceUUID,
         actorDeviceUUID,
         details: "last device — account deregistered",
@@ -647,7 +648,7 @@ Meteor.methods({
 
     await logDeviceAudit({
       userId: this.userId,
-      action: "revoke",
+      action: lost ? "markLost" : "revoke",
       deviceUUID,
       actorDeviceUUID,
       details: deviceLabel(target),

--- a/server/identityMigration.js
+++ b/server/identityMigration.js
@@ -1,12 +1,12 @@
 import { Meteor } from "meteor/meteor";
-import { check } from "meteor/check";
+import { check, Match } from "meteor/check";
 import { DDPRateLimiter } from "meteor/ddp-rate-limiter";
 import { Random } from "meteor/random";
 import crypto from "crypto";
 import { DeviceDetails } from "../utils/api/deviceDetails.js";
 import { MigrationChallenges } from "../utils/api/migrationChallenges.js";
 import { logMigrationEvent } from "../utils/api/migrationEvents.js";
-import { timingSafeEquals } from "./deviceManagement.js";
+import { timingSafeEquals, verifyStepUpAuth } from "./deviceManagement.js";
 import { sendNotification } from "./firebase.js";
 
 /**
@@ -329,6 +329,63 @@ Meteor.methods({
       return { success: true, migrationProof: "fcm-challenge" };
     },
   ),
+
+  /**
+   * Phase 4 fallback: manually approve an installation that could not prove
+   * possession silently (e.g. a phone restored from a cloud backup). Must be
+   * confirmed from a DIFFERENT already-approved device with step-up re-auth —
+   * the account PIN alone from the unproven device is not sufficient. The
+   * unproven device must have a live (unexpired) migration challenge, i.e.
+   * the app was opened on it recently.
+   */
+  "devices.approveIdentityMigration": logged(
+    "manual-approval",
+    async function (options) {
+      check(options, {
+        deviceUUID: String,
+        actorDeviceUUID: String,
+        reAuth: Match.OneOf({ biometricSecret: String }, { pin: String }),
+      });
+      requireLogin(this);
+
+      const { deviceUUID, actorDeviceUUID, reAuth } = options;
+
+      const challenge = await MigrationChallenges.findOneAsync({
+        userId: this.userId,
+        deviceUUID,
+        usedAt: null,
+        expiresAt: { $gt: new Date() },
+      });
+      if (!challenge) {
+        throw new Meteor.Error(
+          "challenge-invalid",
+          "No live migration request for that device. Open the app on it, then try again.",
+        );
+      }
+
+      const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+      const actor = userDoc?.devices?.find(
+        (d) => d.deviceUUID === actorDeviceUUID,
+      );
+
+      if (
+        !actor ||
+        actor.deviceRegistrationStatus !== "approved" ||
+        actor.deviceUUID === challenge.deviceUUID
+      ) {
+        throw new Meteor.Error(
+          "not-authorized",
+          "Approval must come from a different approved device.",
+        );
+      }
+
+      await verifyStepUpAuth(this.userId, reAuth);
+
+      await consumeChallenge(challenge._id);
+      await bindIdentity(this.userId, challenge, "manual-approval");
+      return { success: true, migrationProof: "manual-approval" };
+    },
+  ),
 });
 
 const MIGRATION_METHODS = new Set([
@@ -336,6 +393,7 @@ const MIGRATION_METHODS = new Set([
   "devices.proveMigrationByBiometric",
   "devices.requestMigrationPushChallenge",
   "devices.proveMigrationByPush",
+  "devices.approveIdentityMigration",
 ]);
 
 DDPRateLimiter.addRule(

--- a/tests/identityMigration.js
+++ b/tests/identityMigration.js
@@ -374,6 +374,84 @@ if (Meteor.isServer) {
       });
     });
 
+    describe("devices.approveIdentityMigration", function () {
+      // uuid-pending is unapproved; add a second APPROVED device to act as
+      // the vouching device.
+      beforeEach(async function () {
+        await DeviceDetails.updateAsync(
+          { userId: USER_A },
+          {
+            $push: {
+              devices: {
+                deviceUUID: "uuid-other-approved",
+                appId: "app-other",
+                biometricSecret: "other-approved-secret",
+                fcmToken: "fcm-other",
+                deviceRegistrationStatus: "approved",
+                isPrimary: false,
+                lastUpdated: new Date(),
+              },
+            },
+          },
+        );
+      });
+
+      const approve = (overrides = {}) =>
+        callMethod(
+          "devices.approveIdentityMigration",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-v1",
+            actorDeviceUUID: "uuid-other-approved",
+            reAuth: { biometricSecret: "other-approved-secret" },
+            ...overrides,
+          },
+        );
+
+      it("binds the identity when vouched from another approved device", async function () {
+        await beginMigration(makeKeyPair());
+
+        const result = await approve();
+        assert.strictEqual(result.migrationProof, "manual-approval");
+
+        const doc = await DeviceDetails.findOneAsync({ userId: USER_A });
+        const device = doc.devices.find((d) => d.deviceUUID === "uuid-v1");
+        assert.strictEqual(device.identityVersion, 2);
+        assert.strictEqual(device.migrationProof, "manual-approval");
+      });
+
+      it("rejects approval from the device under migration itself", async function () {
+        await beginMigration(makeKeyPair());
+        await assert.rejects(
+          approve({
+            actorDeviceUUID: "uuid-v1",
+            reAuth: { biometricSecret: BIO_SECRET },
+          }),
+          /not-authorized/,
+        );
+      });
+
+      it("rejects approval from an unapproved device", async function () {
+        await beginMigration(makeKeyPair());
+        await assert.rejects(
+          approve({ actorDeviceUUID: "uuid-pending" }),
+          /not-authorized/,
+        );
+      });
+
+      it("rejects a bad step-up proof", async function () {
+        await beginMigration(makeKeyPair());
+        await assert.rejects(
+          approve({ reAuth: { biometricSecret: "wrong" } }),
+          /reauth-failed/,
+        );
+      });
+
+      it("rejects when the device has no live challenge", async function () {
+        await assert.rejects(approve(), /challenge-invalid/);
+      });
+    });
+
     describe("migration event logging", function () {
       const { MigrationEvents } = require("../utils/api/migrationEvents");
 

--- a/utils/api/deviceDetails.js
+++ b/utils/api/deviceDetails.js
@@ -369,6 +369,7 @@ if (Meteor.isServer) {
     "devices.deviceModel": 1,
     "devices.devicePlatform": 1,
     "devices.deviceRegistrationStatus": 1,
+    "devices.identityVersion": 1,
     "devices.isPrimary": 1,
     "devices.isFirstDevice": 1,
     "devices.isSecondaryDevice": 1,


### PR DESCRIPTION
Closes #455. Stacked on the Phase 3 PR (feat/identity-migration-observability).

## What

Recovery paths for installations that cannot prove possession silently — e.g. the "phone lost in a lake, restored from iCloud onto a replacement" scenario — plus explicit lost-device retirement.

- `devices.approveIdentityMigration` — vouch for an unproven installation from a **different** already-approved device, with step-up re-auth (device-bound biometric secret or PIN). Requires a live (≤5 min) migration challenge, i.e. the app was just opened on the unproven device. Binds `migrationProof: manual-approval`.
- My Devices:
  - **Verify** action appears on approved devices whose installation identity is still unverified (visible from other devices only).
  - **Mark as lost** action reuses the existing `devices.revoke` flow (sessions invalidated, FCM token and biometric secret removed with the device record) but writes a distinct `markLost` audit action so admins can distinguish lost devices from routine removals.
- `devices.identityVersion` added to the owner-only publication projection (inclusion list — no new sensitive fields exposed).

## Security

- The unproven device can never vouch for itself; PIN alone from the unproven device is insufficient.
- Manual approval consumes the challenge (single-use) and never changes `deviceRegistrationStatus`.

## Tests

5 new tests: happy path, self-approval rejected, unapproved actor rejected, bad step-up rejected, no-live-challenge rejected.
