### PR TITLE
Identity migration Phase 5: flag-gated enforcement (closes #456)

### DIFF
--- a/client/mobile/identity-migration.js
+++ b/client/mobile/identity-migration.js
@@ -29,6 +29,24 @@ const isExpectedHalt = (error) =>
   ].includes(error?.error);
 
 /**
+ * Sign a trust-sensitive operation with the installation key (Phase 5).
+ * Returns `{ signedAt, signature }` or null when no identity is available —
+ * the server only rejects missing proofs when IDENTITY_ENFORCEMENT is on.
+ */
+export const signOperation = async (message) => {
+  try {
+    const identity = await getOrCreateIdentity();
+    const signedAt = Date.now();
+    return {
+      signedAt,
+      signature: await identity.sign(`${message}|${signedAt}`),
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Fast path: called right after a successful biometric login, when the
  * device-bound secret is already in hand — no extra prompt, no push needed.
  */

--- a/client/mobile/push-notifications.js
+++ b/client/mobile/push-notifications.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { IOS_APPROVAL_CATEGORIES } from "../../utils/constants.js";
-import { completePushMigration } from "./identity-migration.js";
+import { completePushMigration, signOperation } from "./identity-migration.js";
 
 // Session validation with retry logic
 const validateSessionWithRetry = (callback, retries = 3, interval = 1000) => {
@@ -24,13 +24,17 @@ const validateSessionWithRetry = (callback, retries = 3, interval = 1000) => {
 };
 
 const sendUserAction = (userId, action, notificationId, deviceUUID) => {
-  validateSessionWithRetry(() => {
+  validateSessionWithRetry(async () => {
+    // Phase 5: sign the exact notification + action with the installation
+    // key. Null when unavailable — server accepts that until enforcement.
+    const identityProof = await signOperation(`${notificationId}:${action}`);
     Meteor.call(
       "notifications.handleResponse",
       userId,
       action,
       notificationId,
       deviceUUID,
+      identityProof,
       (error, result) => {
         // Clear the in-flight flag so future notifications can open the modal
         Session.set("actionPerformedFromTray", false);
@@ -159,16 +163,24 @@ const setupTokenReconciliation = () => {
     if (key === lastReconciledKey) return;
     lastReconciledKey = key;
 
-    Meteor.call("devices.updateFCMToken", { deviceUUID, fcmToken }, (error) => {
-      if (error) {
-        // Allow a retry on the next reactive change (e.g. re-login).
-        lastReconciledKey = null;
-        console.warn(
-          "FCM token reconciliation failed:",
-          error.reason || error.message,
+    signOperation(`updateFCMToken:${deviceUUID}:${fcmToken}`).then(
+      (identityProof) => {
+        Meteor.call(
+          "devices.updateFCMToken",
+          { deviceUUID, fcmToken, identityProof },
+          (error) => {
+            if (error) {
+              // Allow a retry on the next reactive change (e.g. re-login).
+              lastReconciledKey = null;
+              console.warn(
+                "FCM token reconciliation failed:",
+                error.reason || error.message,
+              );
+            }
+          },
         );
-      }
-    });
+      },
+    );
   });
 };
 

--- a/client/mobile/src/ui/Login.jsx
+++ b/client/mobile/src/ui/Login.jsx
@@ -159,6 +159,25 @@ export const LoginPage = ({ deviceDetails }) => {
           navigate("/pending-registration");
           return false;
         }
+
+        // Phase 5 (server-flagged): the current installation must itself be
+        // approved and identity-verified — an approved ACCOUNT restored from
+        // a backup is not enough.
+        if (deviceDetails) {
+          const deviceCheck = await Meteor.callAsync(
+            "devices.checkDeviceApproval",
+            { deviceUUID: deviceDetails },
+          );
+          if (
+            deviceCheck.enforced &&
+            (!deviceCheck.approved || deviceCheck.identityVersion !== 2)
+          ) {
+            setError(
+              "This installation hasn't been verified. Approve it from another device (My Devices → Verify) or contact your administrator.",
+            );
+            return false;
+          }
+        }
         return true;
       } catch (err) {
         setError(
@@ -169,7 +188,7 @@ export const LoginPage = ({ deviceDetails }) => {
         setCheckingStatus(false);
       }
     },
-    [navigate],
+    [navigate, deviceDetails],
   );
 
   // ── Biometric login (reusable) ──────────────────────────────────────────
@@ -214,6 +233,12 @@ export const LoginPage = ({ deviceDetails }) => {
                 });
               }
 
+              // The device-bound secret is in hand: silently upgrade this
+              // installation to a v2 identity BEFORE the approval check, so
+              // enforcement doesn't lock out a v1 device that can prove
+              // possession right now.
+              await migrateWithBiometricSecret(biometricSecret);
+
               const isApproved = await checkRegistrationStatus(
                 result._id,
                 result.email,
@@ -228,9 +253,6 @@ export const LoginPage = ({ deviceDetails }) => {
                   username: result.username,
                   _id: result._id,
                 });
-                // Fire-and-forget: the device-bound secret is already in hand,
-                // so upgrade this installation to a v2 identity silently.
-                migrateWithBiometricSecret(biometricSecret);
                 navigate("/dashboard");
               } else {
                 await new Promise((res) => Meteor.logout(res));

--- a/client/mobile/src/ui/hooks/useNotificationHandler.js
+++ b/client/mobile/src/ui/hooks/useNotificationHandler.js
@@ -156,12 +156,19 @@ export const useNotificationHandler = (userId, username) => {
         const deviceInfo = Session.get("capturedDeviceInfo") || {};
         const deviceUUID = deviceInfo.uuid || null;
 
+        const { signOperation } =
+          await import("../../../identity-migration.js");
+        const identityProof = await signOperation(
+          `${notificationIdForAction}:${action}`,
+        );
+
         await Meteor.callAsync(
           "notifications.handleResponse",
           userId,
           action,
           notificationIdForAction,
           deviceUUID,
+          identityProof,
         );
 
         setIsActionsModalOpen(false);

--- a/server/deviceManagement.js
+++ b/server/deviceManagement.js
@@ -10,6 +10,10 @@ import "../utils/api/notificationHistory.js"; // Method registration (primary-tr
 import "../utils/api/pendingResponses.js"; // Method registration (primary-transfer approvals)
 import { APPROVAL_ACTIONS } from "../utils/constants.js";
 import { sendNotification } from "./firebase.js";
+import {
+  requireDeviceProof,
+  isIdentityEnforced,
+} from "./identityEnforcement.js";
 
 /**
  * Self-service device management ("My Devices").
@@ -239,6 +243,26 @@ Meteor.methods({
     return {
       registered: !!device,
       status: device?.deviceRegistrationStatus || null,
+    };
+  },
+
+  /**
+   * Post-login check of the CALLING USER'S current device (Phase 5): the
+   * account-level registrationStatus alone is not enough — a restored backup
+   * can present an approved account from an unverified installation.
+   */
+  async "devices.checkDeviceApproval"({ deviceUUID }) {
+    check(deviceUUID, String);
+    requireLogin(this);
+
+    const userDoc = await DeviceDetails.findOneAsync({ userId: this.userId });
+    const device = userDoc?.devices?.find((d) => d.deviceUUID === deviceUUID);
+
+    return {
+      registered: !!device,
+      approved: device?.deviceRegistrationStatus === "approved",
+      identityVersion: device?.identityVersion || 1,
+      enforced: isIdentityEnforced(),
     };
   },
 
@@ -754,10 +778,16 @@ Meteor.methods({
    * device's registration/approval status.
    */
   async "devices.updateFCMToken"(options) {
-    check(options, { deviceUUID: String, fcmToken: String });
+    check(options, {
+      deviceUUID: String,
+      fcmToken: String,
+      identityProof: Match.Maybe(
+        Match.OneOf(null, { signedAt: Number, signature: String }),
+      ),
+    });
     requireLogin(this);
 
-    const { deviceUUID, fcmToken } = options;
+    const { deviceUUID, fcmToken, identityProof } = options;
 
     if (!fcmToken || fcmToken.length > 4096) {
       throw new Meteor.Error("invalid-token", "Invalid FCM token.");
@@ -771,6 +801,14 @@ Meteor.methods({
     if (!device || device.fcmToken === fcmToken) {
       return { success: true, updated: false };
     }
+
+    // Phase 5 (flag-gated): token replacement must be signed by the device's
+    // verified installation key.
+    requireDeviceProof(
+      device,
+      `updateFCMToken:${deviceUUID}:${fcmToken}`,
+      identityProof,
+    );
 
     await DeviceDetails.updateAsync(
       { userId: this.userId, "devices.deviceUUID": deviceUUID },
@@ -792,6 +830,7 @@ const RATE_LIMITED_METHODS = new Set([
   "users.loginWithBiometric",
   "users.register",
   "devices.checkRegistrationByUUID",
+  "devices.checkDeviceApproval",
   "devices.updateInfo",
   "devices.updateFCMToken",
   "devices.rename",

--- a/server/identityEnforcement.js
+++ b/server/identityEnforcement.js
@@ -1,0 +1,56 @@
+import { Meteor } from "meteor/meteor";
+import { verifySignature } from "./identityMigration.js";
+
+// Phase 5 enforcement (migration-plan.md): when IDENTITY_ENFORCEMENT=true,
+// trust-sensitive operations require the acting device to hold a v2
+// installation identity and to sign the operation with it. Flag off = zero
+// behavior change (rollout is gated on >90% v2 coverage, see admin
+// diagnostics).
+
+export const isIdentityEnforced = () =>
+  process.env.IDENTITY_ENFORCEMENT === "true";
+
+// Reject proofs signed too long ago so captured signatures can't be replayed
+// indefinitely.
+const PROOF_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Require a v2 device plus a fresh signature over `message` when enforcement
+ * is on. `proof` is `{ signedAt: Number (ms epoch), signature: String }`,
+ * signed as `${message}|${signedAt}` by the installation key.
+ */
+export const requireDeviceProof = (device, message, proof) => {
+  if (!isIdentityEnforced()) return;
+
+  if (!device || device.identityVersion !== 2 || !device.publicKey) {
+    throw new Meteor.Error(
+      "identity-required",
+      "This device's installation identity has not been verified. Verify it from another device or contact your administrator.",
+    );
+  }
+
+  const signedAt = Number(proof?.signedAt);
+  if (
+    !proof?.signature ||
+    !Number.isFinite(signedAt) ||
+    Math.abs(Date.now() - signedAt) > PROOF_MAX_AGE_MS
+  ) {
+    throw new Meteor.Error(
+      "identity-proof-invalid",
+      "Missing or expired device signature. Please update the app and try again.",
+    );
+  }
+
+  if (
+    !verifySignature(
+      device.publicKey,
+      `${message}|${signedAt}`,
+      proof.signature,
+    )
+  ) {
+    throw new Meteor.Error(
+      "identity-proof-invalid",
+      "Device signature verification failed.",
+    );
+  }
+};

--- a/server/identityMigration.js
+++ b/server/identityMigration.js
@@ -41,7 +41,7 @@ const asP256KeyObject = (publicKeyB64) => {
 };
 
 // WebCrypto ECDSA produces IEEE P1363 (r||s) signatures over SHA-256.
-const verifySignature = (publicKeyB64, message, signatureB64) => {
+export const verifySignature = (publicKeyB64, message, signatureB64) => {
   const keyObject = asP256KeyObject(publicKeyB64);
   if (!keyObject) return false;
   try {

--- a/server/main.js
+++ b/server/main.js
@@ -16,6 +16,7 @@ import {
   notifyApprovedDevices,
 } from "./deviceManagement.js"; // Also registers self-service device management methods + rate limiting
 import "./identityMigration.js"; // v1 -> v2 installation-identity migration methods
+import { requireDeviceProof } from "./identityEnforcement.js";
 import { NotificationHistory } from "../utils/api/notificationHistory.js";
 import { ApprovalTokens } from "../utils/api/approvalTokens";
 import { PendingResponses } from "../utils/api/pendingResponses.js";
@@ -1369,11 +1370,14 @@ Meteor.methods({
     action,
     notificationIdForAction,
     respondingDeviceUUID = null,
+    identityProof = null,
   ) {
     check(userId, String);
     check(action, Match.OneOf("approve", "reject"));
     check(notificationIdForAction, String);
     if (respondingDeviceUUID) check(respondingDeviceUUID, String);
+    if (identityProof)
+      check(identityProof, { signedAt: Number, signature: String });
 
     // Require an authenticated Meteor session — anonymous callers must not be
     // able to approve or reject another user's pending notifications.
@@ -1434,6 +1438,14 @@ Meteor.methods({
           "Your device registration is still pending admin approval. You cannot respond to notifications until your device is approved.",
         );
       }
+
+      // Phase 5 (flag-gated): the responding device must hold a verified v2
+      // identity and sign the exact notification + action it responds to.
+      requireDeviceProof(
+        respondingDevice,
+        `${notificationIdForAction}:${action}`,
+        identityProof,
+      );
 
       // Record last activity on the responding device (shown in My Devices).
       await DeviceDetails.updateAsync(

--- a/tests/identityMigration.js
+++ b/tests/identityMigration.js
@@ -452,6 +452,140 @@ if (Meteor.isServer) {
       });
     });
 
+    describe("identity enforcement (IDENTITY_ENFORCEMENT flag)", function () {
+      const migrateDeviceV1ToV2 = async () => {
+        const keyPair = makeKeyPair();
+        const { challengeId, signingChallenge } = await beginMigration(keyPair);
+        await callMethod(
+          "devices.proveMigrationByBiometric",
+          { userId: USER_A },
+          {
+            challengeId,
+            biometricSecret: BIO_SECRET,
+            signedChallenge: keyPair.sign(signingChallenge),
+          },
+        );
+        return keyPair;
+      };
+
+      afterEach(function () {
+        delete process.env.IDENTITY_ENFORCEMENT;
+      });
+
+      it("flag off: token update succeeds without a proof", async function () {
+        const result = await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_A },
+          { deviceUUID: "uuid-v1", fcmToken: "fcm-rotated" },
+        );
+        assert.strictEqual(result.updated, true);
+      });
+
+      it("flag on: rejects a v1 device without identity", async function () {
+        process.env.IDENTITY_ENFORCEMENT = "true";
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: USER_A },
+            { deviceUUID: "uuid-v1", fcmToken: "fcm-rotated" },
+          ),
+          /identity-required/,
+        );
+      });
+
+      it("flag on: rejects a missing or stale proof from a v2 device", async function () {
+        const keyPair = await migrateDeviceV1ToV2();
+        process.env.IDENTITY_ENFORCEMENT = "true";
+
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: USER_A },
+            { deviceUUID: "uuid-v1", fcmToken: "fcm-rotated" },
+          ),
+          /identity-proof-invalid/,
+        );
+
+        const staleSignedAt = Date.now() - 10 * 60 * 1000;
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-v1",
+              fcmToken: "fcm-rotated",
+              identityProof: {
+                signedAt: staleSignedAt,
+                signature: keyPair.sign(
+                  `updateFCMToken:uuid-v1:fcm-rotated|${staleSignedAt}`,
+                ),
+              },
+            },
+          ),
+          /identity-proof-invalid/,
+        );
+      });
+
+      it("flag on: accepts a fresh valid proof from a v2 device", async function () {
+        const keyPair = await migrateDeviceV1ToV2();
+        process.env.IDENTITY_ENFORCEMENT = "true";
+
+        const signedAt = Date.now();
+        const result = await callMethod(
+          "devices.updateFCMToken",
+          { userId: USER_A },
+          {
+            deviceUUID: "uuid-v1",
+            fcmToken: "fcm-rotated",
+            identityProof: {
+              signedAt,
+              signature: keyPair.sign(
+                `updateFCMToken:uuid-v1:fcm-rotated|${signedAt}`,
+              ),
+            },
+          },
+        );
+        assert.strictEqual(result.updated, true);
+      });
+
+      it("flag on: rejects a proof signed by a different key", async function () {
+        await migrateDeviceV1ToV2();
+        const attacker = makeKeyPair();
+        process.env.IDENTITY_ENFORCEMENT = "true";
+
+        const signedAt = Date.now();
+        await assert.rejects(
+          callMethod(
+            "devices.updateFCMToken",
+            { userId: USER_A },
+            {
+              deviceUUID: "uuid-v1",
+              fcmToken: "fcm-rotated",
+              identityProof: {
+                signedAt,
+                signature: attacker.sign(
+                  `updateFCMToken:uuid-v1:fcm-rotated|${signedAt}`,
+                ),
+              },
+            },
+          ),
+          /identity-proof-invalid/,
+        );
+      });
+
+      it("devices.checkDeviceApproval reports device state and flag", async function () {
+        const result = await callMethod(
+          "devices.checkDeviceApproval",
+          { userId: USER_A },
+          { deviceUUID: "uuid-v1" },
+        );
+        assert.strictEqual(result.registered, true);
+        assert.strictEqual(result.approved, true);
+        assert.strictEqual(result.identityVersion, 1);
+        assert.strictEqual(result.enforced, false);
+      });
+    });
+
     describe("migration event logging", function () {
       const { MigrationEvents } = require("../utils/api/migrationEvents");
 


### PR DESCRIPTION
Closes #456. Stacked on the Phase 4 PR (feat/identity-migration-fallback). Ships dark — `IDENTITY_ENFORCEMENT` defaults off (zero behavior change) until the Phase 3 coverage gate (>90% of 30-day-active devices at v2) is met.

## What

When `IDENTITY_ENFORCEMENT=true`:

- `notifications.handleResponse` — the responding device must hold a verified v2 identity and present a fresh (≤5 min) signature over `notificationId:action` by its installation key.
- `devices.updateFCMToken` — token replacement must be signed over `updateFCMToken:deviceUUID:newToken`.
- `devices.checkDeviceApproval` (new) — post-login check of the **current installation** (approved + identity version + enforcement state). Login blocks unverified installations only when the server reports enforcement is on, with copy routing the user to the Phase 4 fallback (Verify from another device / contact admin).

## Client

- Operations are signed with the installation key (`signOperation`); proofs are `null` and accepted while the flag is off, so old and new clients coexist during rollout.
- Biometric login now runs the silent migration **before** the approval check, so a v1 device that can prove possession is never locked out by enforcement.

## Replay protection

Proofs embed a client timestamp and are rejected when older than 5 minutes or signed by any key other than the device's bound installation key.

## Tests

6 new tests: flag off passthrough, v1 rejection, missing/stale proof rejection, foreign-key rejection, valid proof acceptance, checkDeviceApproval contract.

## Out of scope (issue #457, blocked on the enforcement deadline)

Removing v1 acceptance paths, `device.uuid` from security decisions, and the flag itself.
