### PR TITLE
Fix npm ERESOLVE peer conflicts breaking the deploy workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,14 +25,14 @@
         "qrcode": "^1.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router": "^8.3.0",
+        "react-router": "^7.18.2",
         "react-router-dom": "^7.18.2",
         "readline-sync": "^1.4.10"
       },
       "devDependencies": {
         "@meteorjs/rspack": "^1.0.0",
         "@rsdoctor/rspack-plugin": "^1.2.3",
-        "@rspack/cli": "^2.1.2",
+        "@rspack/cli": "^1.7.12",
         "@rspack/core": "^1.7.1",
         "@rspack/plugin-react-refresh": "^1.4.3",
         "@tailwindcss/postcss": "^4.1.18",
@@ -2255,22 +2255,22 @@
       ]
     },
     "node_modules/@rspack/cli": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-2.1.2.tgz",
-      "integrity": "sha512-GTBsKuaeqDii6NaGPkQwvycMSjqMUMMRGiAwH0sXsFIn8X7sFa4xpoL7pIhbebVBDGzYhUBqWzNQFuL5u2FeoQ==",
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-1.7.12.tgz",
+      "integrity": "sha512-aiVj5hm12/rhkH/KTvs9BugpRuLEutIw5o3KmQDvSMd6EqEIASuCCUI3/97uaNP58hqZSl7mAotsLcwn/OCbJQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.7",
+        "@rspack/dev-server": "~1.1.5",
+        "exit-hook": "^4.0.0",
+        "webpack-bundle-analyzer": "4.10.2"
+      },
       "bin": {
         "rspack": "bin/rspack.js"
       },
       "peerDependencies": {
-        "@rspack/core": "^2.0.0-0",
-        "@rspack/dev-server": "^2.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/dev-server": {
-          "optional": true
-        }
+        "@rspack/core": "^1.0.0-alpha || ^1.x"
       }
     },
     "node_modules/@rspack/core": {
@@ -4723,12 +4723,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-es": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
-      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -11945,19 +11939,20 @@
       }
     },
     "node_modules/react-router": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
-      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^3.1.1"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=22.22.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=19.2.7",
-        "react-dom": ">=19.2.7"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -11981,7 +11976,7 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-router-dom/node_modules/cookie": {
+    "node_modules/react-router/node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
@@ -11992,28 +11987,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "qrcode": "^1.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router": "^8.3.0",
+    "react-router": "^7.18.2",
     "react-router-dom": "^7.18.2",
     "readline-sync": "^1.4.10"
   },
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@meteorjs/rspack": "^1.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@rspack/cli": "^2.1.2",
+    "@rspack/cli": "^1.7.12",
     "@rspack/core": "^1.7.1",
     "@rspack/plugin-react-refresh": "^1.4.3",
     "@tailwindcss/postcss": "^4.1.18",


### PR DESCRIPTION
Fixes the deploy-server failure in https://github.com/mieweb/mieweb_auth_app/actions/runs/31433175230/job/93601333991

**Root cause:** `npm install` fails with ERESOLVE:
1. `@rspack/cli@^2.1.2` requires peer `@rspack/core@^2.0.0-0`, but the project pins `@rspack/core@^1.7.1` (and `@meteorjs/rspack@1.0.2` sits on the 1.x line).
2. Once past that, `react-router@^8.3.0` requires `react >=19.2.7`, but the project uses React 18.

**Fix:**
- `@rspack/cli` `^2.1.2` → `^1.7.12` (latest 1.x, matches `@rspack/core@^1.7.1`)
- `react-router` `^8.3.0` → `^7.18.2` (matches `react-router-dom@^7.18.2` and React 18; the one direct `react-router` import is API-compatible in v7)
- Lockfile regenerated; `npm install` verified clean locally (resolved tree: rspack cli 1.7.12 / core 1.7.11, react-router 7.18.2 deduped with react-router-dom).