### PR TITLE
Enable Safari Web Inspector for the iOS WKWebView (iOS 16.4+)

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.5.10',
+  version: "1.5.10",
 });
 
 App.setPreference("android-targetSdkVersion", "36");
@@ -34,6 +34,10 @@ App.setPreference("SplashScreenBackgroundColor", "#27AAE1");
 // Enable camera access in WebView for html5-qrcode (getUserMedia)
 App.setPreference("AllowInlineMediaPlayback", true);
 App.setPreference("CordovaWebViewEngine", "CDVWKWebViewEngine", "ios");
+
+// iOS 16.4+ blocks Safari Web Inspector unless the WKWebView opts in
+// (Safari > Develop > <device> shows nothing otherwise).
+App.setPreference("InspectableWebview", true, "ios");
 
 // Add necessary iOS permissions for Camera
 App.appendToConfig(`


### PR DESCRIPTION
**Problem:** The app no longer appears under Safari > Develop > \<device\> when trying to inspect the WebView from a Mac.

**Root cause:** Since iOS 16.4, `WKWebView.isInspectable` defaults to `false`, so Safari Web Inspector cannot attach unless the app opts in.

**Fix:** Set the cordova-ios `InspectableWebview` preference (iOS only) in `mobile-config.js`, which sets `isInspectable = true` on the WebView.

**Notes:**
- Requires a fresh native build/reinstall — a hot code push does not apply `config.xml` preferences.
- This makes the WebView inspectable in release builds too; we may want to strip it (or gate it on an env flag) before store releases.
- Native plugin code is unaffected; that still debugs through Xcode.
