### PR TITLE
feat: add MIE Auth instance deployment (mieauth.mieweb.org)

### DIFF
--- a/.github/workflows/deploy-mieauth.yml
+++ b/.github/workflows/deploy-mieauth.yml
@@ -1,0 +1,478 @@
+name: Deploy MIE Auth - Server, Android & iOS (mieauth.mieweb.org)
+
+# ───────────────────────────────────────────────────
+# Deployment for the MIE-internal MIEAuth instance at
+# mieauth.mieweb.org, running on the mie-fwdc-auth1 self-hosted
+# runner with its own database and user base.
+#
+# This is NOT the opensource app — that stays on
+# mieauth-prod.os.mieweb.org via deploy-production.yml, and
+# keeps the com.mieweb.mieauth / org.mieweb.opensource IDs.
+#
+# Triggers:
+#   - releases tagged mie-v*
+#   - manual dispatch (server-only by default)
+# ─────────────────────────────────────────────────────────
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or tag to deploy"
+        required: false
+        default: main
+      include_mobile:
+        description: "Also build and publish the mobile apps"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  SERVER_URL: https://mieauth.mieweb.org
+  SERVER_HOST: mieauth.mieweb.org
+  # Distinct from the opensource app so both can coexist on one device.
+  APP_ID: org.mieweb.auth
+  URL_SCHEME: miewebauth
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Gate: release must use the mie-v* prefix.
+  # Manual dispatch always proceeds.
+  # ─────────────────────────────────────────────
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      build_mobile: ${{ steps.check.outputs.build_mobile }}
+      app_version: ${{ steps.check.outputs.app_version }}
+      build_date: ${{ steps.check.outputs.build_date }}
+    steps:
+      - name: Check trigger and resolve version
+        id: check
+        run: |
+          BUILD_DATE=$(date +%m-%d-%Y)
+          echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "build_mobile=${{ inputs.include_mobile }}" >> "$GITHUB_OUTPUT"
+            echo "app_version=0.0.0-dispatch" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — proceeding (mobile: ${{ inputs.include_mobile }})"
+            exit 0
+          fi
+
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ "$TAG" == mie-v* ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "build_mobile=true" >> "$GITHUB_OUTPUT"
+            # mie-v1.2.3 -> 1.2.3
+            echo "app_version=${TAG#mie-v}" >> "$GITHUB_OUTPUT"
+            echo "Tag '${TAG}' matches mie-v* — proceeding"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "build_mobile=false" >> "$GITHUB_OUTPUT"
+            echo "Tag '${TAG}' is not a mie-v* tag — skipping"
+          fi
+
+  # ─────────────────────────────────────────────
+  # Server — builds locally on mie-fwdc-auth1
+  # ─────────────────────────────────────────────
+  deploy-server:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Build and Restart MIEAuth
+        run: |
+          set -e
+
+          echo "=== Generating build info ==="
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+          node generate-build-info.js
+
+          echo "=== Installing project dependencies ==="
+          export PATH="$HOME/.meteor:$PATH"
+          meteor npm install
+
+          echo "=== Building Meteor server ==="
+          # 4 GB container — cap the build heap so the tool is not OOM-killed.
+          export TOOL_NODE_FLAGS="--max-old-space-size=3072"
+          BUILD_DIR="$HOME/Builds/Webserver-build-$(date +%m-%d-%Y-%H%M%S)"
+          meteor build "${BUILD_DIR}" \
+            --directory \
+            --server-only \
+            --server="${SERVER_URL}"
+
+          echo "=== Installing bundle server dependencies ==="
+          cd "${BUILD_DIR}/bundle/programs/server"
+          npm install
+
+          echo "=== Installing bundle-level dependencies ==="
+          cd "${BUILD_DIR}/bundle"
+          npm install @babel/runtime
+
+          echo "=== Updating symlink ==="
+          ln -sfn "${BUILD_DIR}/bundle" "$HOME/Builds/current"
+
+          echo "=== Restarting service ==="
+          sudo systemctl restart mieauth
+
+          echo "=== Health check ==="
+          sleep 10
+          if sudo systemctl is-active --quiet mieauth; then
+            echo "Server deployed and running successfully"
+            sudo systemctl status mieauth --no-pager
+          else
+            echo "Server failed to start"
+            sudo journalctl -u mieauth --no-pager -n 50
+            exit 1
+          fi
+
+          echo "=== Cleaning up old builds (keeping latest 3) ==="
+          cd "$HOME/Builds"
+          ls -dt Webserver-build-* 2>/dev/null | tail -n +4 | while read old_build; do
+            echo "Removing old build: ${old_build}"
+            rm -rf "${old_build}"
+          done
+
+      - name: Verify Server Health (HTTP)
+        run: |
+          for i in 1 2 3 4 5; do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${SERVER_URL}" || echo "000")
+            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+              echo "Server responding with HTTP ${HTTP_STATUS}"
+              exit 0
+            fi
+            echo "Attempt ${i}: HTTP ${HTTP_STATUS}, retrying in 10s..."
+            sleep 10
+          done
+          echo "Server not responding after 5 attempts"
+          echo "If this is HTTP 502, check the Cloudflare tunnel public hostname"
+          echo "maps ${SERVER_HOST} to HTTP localhost:3000."
+          exit 1
+
+  # ─────────────────────────────────────────────
+  # Android → Play Store
+  # ─────────────────────────────────────────────
+  build-and-publish-android:
+    needs: prepare
+    if: ${{ !cancelled() && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.build_mobile == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      APP_VERSION: ${{ needs.prepare.outputs.app_version }}
+      BUILD_DATE: ${{ needs.prepare.outputs.build_date }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Meteor
+        run: |
+          curl https://install.meteor.com/ | sh
+          echo "$HOME/.meteor" >> $GITHUB_PATH
+
+      - name: Install Dependencies
+        run: meteor npm install
+
+      - name: Decode Firebase config
+        run: |
+          mkdir -p private/android private/ios
+          echo "${{ secrets.MIE_FIREBASE_SERVICES_JSON_BASE64 }}" | base64 -d > private/android/google-services.json
+          echo "${{ secrets.MIE_FIREBASE_IOS_PLIST_BASE64 }}" | base64 -d > private/ios/GoogleService-Info.plist
+
+      - name: Generate build info
+        run: node generate-build-info.js
+
+      - name: Patch mobile-config.js for this instance
+        run: |
+          sed -i "s/id: ['\"]org.mieweb.opensource['\"]/id: '${APP_ID}'/" mobile-config.js
+          sed -i "s/URL_SCHEME: ['\"]mieauth['\"]/URL_SCHEME: \"${URL_SCHEME}\"/" mobile-config.js
+          sed -i "s|website: ['\"]https://mieauth-prod.os.mieweb.org['\"]|website: \"${SERVER_URL}\"|" mobile-config.js
+          if [ "${APP_VERSION}" != "0.0.0-dispatch" ]; then
+            sed -i "s/version: ['\"][^'\"]*['\"]/version: '${APP_VERSION}'/" mobile-config.js
+          fi
+          grep -E "id:|version:|website:|URL_SCHEME" mobile-config.js
+
+      - name: Build Android AAB
+        run: |
+          meteor build ./android-build \
+            --platforms android \
+            --server="${SERVER_URL}"
+
+      - name: Decode Keystore
+        run: echo "${{ secrets.MIE_ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > mieauth-release-key.jks
+
+      - name: Sign AAB
+        run: |
+          UNSIGNED_AAB=$(find android-build -name "*.aab" -type f | head -1)
+          if [ -z "$UNSIGNED_AAB" ]; then
+            echo "ERROR: No AAB file found"
+            find android-build -type f
+            exit 1
+          fi
+          echo "Found AAB: ${UNSIGNED_AAB}"
+
+          jarsigner -verbose \
+            -sigalg SHA256withRSA \
+            -digestalg SHA-256 \
+            -keystore mieauth-release-key.jks \
+            -storepass "${{ secrets.MIE_ANDROID_KEYSTORE_PASSWORD }}" \
+            -keypass "${{ secrets.MIE_ANDROID_KEY_PASSWORD }}" \
+            "$UNSIGNED_AAB" \
+            "${{ secrets.MIE_ANDROID_KEYSTORE_ALIAS }}"
+
+          jarsigner -verify -verbose -certs "$UNSIGNED_AAB"
+
+          SIGNED_AAB="MIEAuth-${APP_VERSION}_${BUILD_DATE}.aab"
+          cp "$UNSIGNED_AAB" "$SIGNED_AAB"
+          echo "SIGNED_AAB=${SIGNED_AAB}" >> $GITHUB_ENV
+
+      - name: Upload to Google Play Store
+        if: github.event_name == 'release'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.MIE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: org.mieweb.auth
+          releaseFiles: ${{ env.SIGNED_AAB }}
+          track: internal
+          status: completed
+          releaseName: "MIE Auth v${{ env.APP_VERSION }}"
+
+      - name: Upload AAB as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mieauth-signed-aab
+          path: ${{ env.SIGNED_AAB }}
+          retention-days: 90
+
+  # ─────────────────────────────────────────────
+  # iOS → TestFlight
+  # ─────────────────────────────────────────────
+  build-and-publish-ios:
+    needs: prepare
+    if: ${{ !cancelled() && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.build_mobile == 'true' }}
+    runs-on: macos-latest
+    env:
+      APP_VERSION: ${{ needs.prepare.outputs.app_version }}
+      BUILD_DATE: ${{ needs.prepare.outputs.build_date }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Select Xcode 26
+        run: |
+          LATEST_XCODE=$(ls -td /Applications/Xcode_26*.app 2>/dev/null | head -n 1 || true)
+          if [ -z "$LATEST_XCODE" ]; then
+            LATEST_XCODE=$(ls -td /Applications/Xcode*.app | grep -v -i -E '(beta|rc|gm|seed|preview)' | head -n 1)
+          fi
+          echo "Selected Xcode: $LATEST_XCODE"
+          sudo xcode-select -s "$LATEST_XCODE/Contents/Developer"
+          xcodebuild -version
+
+      - name: Install Meteor
+        run: |
+          curl https://install.meteor.com/ | sh
+          echo "$HOME/.meteor" >> $GITHUB_PATH
+
+      - name: Install Dependencies
+        run: meteor npm install
+
+      - name: Decode Firebase config
+        run: |
+          mkdir -p private/android private/ios
+          echo "${{ secrets.MIE_FIREBASE_IOS_PLIST_BASE64 }}" | base64 -d > private/ios/GoogleService-Info.plist
+          echo "${{ secrets.MIE_FIREBASE_SERVICES_JSON_BASE64 }}" | base64 -d > private/android/google-services.json
+
+      - name: Generate build info
+        run: node generate-build-info.js
+
+      - name: Patch mobile-config.js for this instance
+        run: |
+          sed -i '' "s/id: ['\"]org.mieweb.opensource['\"]/id: '${APP_ID}'/" mobile-config.js
+          sed -i '' "s/URL_SCHEME: ['\"]mieauth['\"]/URL_SCHEME: \"${URL_SCHEME}\"/" mobile-config.js
+          sed -i '' "s|website: ['\"]https://mieauth-prod.os.mieweb.org['\"]|website: \"${SERVER_URL}\"|" mobile-config.js
+          if [ "${APP_VERSION}" != "0.0.0-dispatch" ]; then
+            sed -i '' "s/version: ['\"][^'\"]*['\"]/version: '${APP_VERSION}'/" mobile-config.js
+          fi
+          grep -E "id:|version:|website:|URL_SCHEME" mobile-config.js
+
+      - name: Build iOS
+        run: |
+          meteor build ./ios-build \
+            --platforms ios \
+            --server="${SERVER_URL}"
+
+      - name: Install Apple Certificate & Provisioning Profile
+        env:
+          CERT_P12_BASE64: ${{ secrets.MIE_IOS_DIST_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MIE_IOS_DIST_CERT_PASSWORD }}
+          PROV_PROFILE_BASE64: ${{ secrets.MIE_IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          echo "$CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$CERT_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          echo "$PROV_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | grep -A1 UUID | grep string | sed 's/.*<string>\(.*\)<\/string>/\1/')
+          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
+
+          echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> $GITHUB_ENV
+          echo "PROFILE_UUID=${PROFILE_UUID}" >> $GITHUB_ENV
+
+      - name: Verify profile matches this app
+        run: |
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          echo "=== Profile application-identifier ==="
+          security cms -D -i "$PROFILE_PATH" | grep -A2 "application-identifier" || true
+          if ! security cms -D -i "$PROFILE_PATH" | grep -q "${APP_ID}"; then
+            echo "ERROR: provisioning profile does not cover ${APP_ID}"
+            exit 1
+          fi
+          security find-identity -v -p codesigning "${KEYCHAIN_PATH}" || true
+
+      - name: Archive iOS App
+        run: |
+          set -euo pipefail
+
+          PODFILE_PATH=$(find ios-build -name "Podfile" -type f | head -1)
+          if [ -n "$PODFILE_PATH" ]; then
+            PODFILE_DIR=$(dirname "$PODFILE_PATH")
+            echo "Found Podfile at: ${PODFILE_DIR}"
+            cd "$PODFILE_DIR"
+            pod install
+            cd -
+          fi
+
+          WORKSPACE_PATH=$(find ios-build -name "*.xcworkspace" -not -path "*/*.xcodeproj/*" -type d | head -1)
+          if [ -z "$WORKSPACE_PATH" ]; then
+            WORKSPACE_PATH=$(find ios-build -name "*.xcworkspace" -type d | head -1)
+          fi
+          echo "Using workspace: ${WORKSPACE_PATH}"
+
+          xcodebuild -workspace "$WORKSPACE_PATH" -list 2>/dev/null || true
+          SCHEME=$(basename "$WORKSPACE_PATH" .xcworkspace)
+          echo "Using app scheme: ${SCHEME}"
+
+          if ! xcodebuild -workspace "$WORKSPACE_PATH" -list 2>/dev/null | grep -qF "$SCHEME"; then
+            echo "ERROR: Scheme '${SCHEME}' not found in workspace"
+            exit 1
+          fi
+
+          xcodebuild archive \
+            -workspace "$WORKSPACE_PATH" \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath $RUNNER_TEMP/MIEAuth.xcarchive \
+            -allowProvisioningUpdates \
+            OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM=${{ secrets.MIE_APPLE_TEAM_ID }} \
+            PROVISIONING_PROFILE_SPECIFIER="${PROFILE_UUID}"
+
+      - name: Export iOS App
+        run: |
+          set -euo pipefail
+
+          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>${APP_ID}</key>
+                  <string>${PROFILE_UUID}</string>
+              </dict>
+          </dict>
+          </plist>
+          EOF
+
+          mkdir -p ~/private_keys
+          echo "${{ secrets.MIE_APPLE_API_KEY_P8_BASE64 }}" | base64 --decode > ~/private_keys/AuthKey_${{ secrets.MIE_APPLE_API_KEY_ID }}.p8
+
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/MIEAuth.xcarchive \
+            -exportPath $RUNNER_TEMP/export \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.MIE_APPLE_API_KEY_ID }}.p8 \
+            -authenticationKeyID ${{ secrets.MIE_APPLE_API_KEY_ID }} \
+            -authenticationKeyIssuerID ${{ secrets.MIE_APPLE_API_ISSUER_ID }}
+
+      - name: Upload to TestFlight
+        if: github.event_name == 'release'
+        env:
+          API_KEY_ID: ${{ secrets.MIE_APPLE_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.MIE_APPLE_API_ISSUER_ID }}
+          API_KEY_P8_BASE64: ${{ secrets.MIE_APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          mkdir -p ~/private_keys
+          echo "$API_KEY_P8_BASE64" | base64 --decode > ~/private_keys/AuthKey_${API_KEY_ID}.p8
+
+          IPA_PATH=$(find $RUNNER_TEMP/export -name "*.ipa" -type f | head -1)
+          echo "Uploading IPA: ${IPA_PATH}"
+
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$IPA_PATH" \
+            --apiKey "$API_KEY_ID" \
+            --apiIssuer "$API_ISSUER_ID"
+
+      - name: Upload IPA as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mieauth-ipa
+          path: ${{ runner.temp }}/export/*.ipa
+          retention-days: 90
+
+      - name: Cleanup Keychain
+        if: always()
+        run: security delete-keychain ${{ env.KEYCHAIN_PATH }} || true

--- a/.gitignore
+++ b/.gitignore
@@ -177,5 +177,8 @@ set-env-*.sh
 set-env.sh
 setup-dev-server.sh
 
+# Local MIE instance mobile builds
+mie-build/
+
 # Android App Bundles
 *.aab

--- a/docs/MIEAUTH_INSTANCE.md
+++ b/docs/MIEAUTH_INSTANCE.md
@@ -1,0 +1,184 @@
+# MIE Auth Instance — `mieauth.mieweb.org`
+
+Setup notes for the **MIE-internal** MIEAuth instance on host `mie-fwdc-auth1`.
+
+This is a **separate application** from the opensource app. It has its own
+database and its own user base — nothing is migrated from
+`mieauth-prod.os.mieweb.org`, which continues to run untouched via
+[deploy-production.yml](.github/workflows/deploy-production.yml).
+
+|             | Opensource app                 | MIE instance                          |
+| ----------- | ------------------------------ | ------------------------------------- |
+| URL         | `mieauth-prod.os.mieweb.org`   | `mieauth.mieweb.org`                  |
+| Host        | Proxmox container (SSH deploy) | `mie-fwdc-auth1` (self-hosted runner) |
+| Workflow    | `deploy-production.yml`        | `deploy-mieauth.yml`                  |
+| Release tag | `v*`                           | `mie-v*`                              |
+| Database    | `mieweb_auth`, standalone      | `mieauth`, replica set `mieauth-rs`   |
+| Users       | Existing                       | Fresh — no import                     |
+
+## Host facts
+
+Audited 2026-08-17 via [scripts/server-inventory.sh](scripts/server-inventory.sh):
+
+| Item                | State                                                                   |
+| ------------------- | ----------------------------------------------------------------------- |
+| OS                  | Debian 12 bookworm, LXC container, 4 CPU, 4 GB RAM + 4 GB swap          |
+| Sudo user           | `aabrol` (uid 7548, group `mieremote`), passwordless sudo               |
+| Service/runner user | `actions` — owns the toolchain and `~/Builds`                           |
+| MongoDB             | 8.0.29, replica set `mieauth-rs`, authenticated, database `mieauth`     |
+| TLS / ingress       | cloudflared tunnel — no nginx, no certbot                               |
+| Actions runner      | `actions.runner.mieweb-mieweb_auth_app.mie-fwdc-auth1`                  |
+| Mail                | `smtp-lb.med-web.com:25`                                                |
+| LDAP                | `ldaps://ldap.med-web.com:636` (med-web.com directory; no SSSD on host) |
+
+## 1. Provisioning
+
+```bash
+TARGET_USER=actions bash scripts/provision-server.sh
+```
+
+The runner executes as `actions` while `aabrol` holds sudo, so the script does
+system-level work (apt) as the invoking user and installs the per-user toolchain
+as `actions`. Node, Meteor, and `~/Builds` must belong to `actions` or the CI job
+cannot find them.
+
+## 2. Ingress — Cloudflare Tunnel, not nginx
+
+Cloudflare terminates TLS; there is no vhost or certificate to manage. The tunnel
+is **dashboard-managed** (`cloudflared tunnel run --token-file /etc/cloudflared/token`),
+so there is no `config.yml` on the server. Routing is set in:
+
+> Zero Trust → Networks → Tunnels → _(mie-fwdc-auth1 tunnel)_ → Public Hostname
+
+with `mieauth.mieweb.org` → service **HTTP** `localhost:3000`.
+
+WebSocket upgrades (Meteor's DDP) are proxied automatically. A **502** means
+nothing is listening on port 3000 yet.
+
+## 3. Environment
+
+`/home/actions/scripts/set-env.sh`, owned by `actions`, mode `600`:
+
+```bash
+export ROOT_URL='https://mieauth.mieweb.org'
+export APP_URL='https://mieauth.mieweb.org'
+export PORT=3000
+export MAIL_URL='smtp://smtp-lb.med-web.com:25'
+export MONGO_URL='mongodb://mieauth:<PASSWORD>@mie-fwdc-auth1.med-web.com:27017/mieauth?replicaSet=mieauth-rs&authSource=admin'
+export MONGO_OPLOG_URL='mongodb://mieauth:<PASSWORD>@mie-fwdc-auth1.med-web.com:27017/local?replicaSet=mieauth-rs&authSource=admin'
+
+# LDAP (admin panel) — med-web.com directory, not the mieweb.org cluster
+export LDAP_URL="ldaps://ldap.med-web.com:636"
+export LDAP_BASE_DN="dc=med-web,dc=com"
+export LDAP_USER_BASE_DN="ou=people,dc=med-web,dc=com"
+export LDAP_USER_RDN_ATTR="uid"
+export LDAP_BIND_DN="uid=proxyuser,dc=med-web,dc=com"
+export LDAP_BIND_PASSWORD="<LDAP_BIND_PASSWORD>"
+export LDAP_ADMIN_GROUP_DN="cn=mie,ou=secgroup,dc=med-web,dc=com"
+export LDAP_GROUP_MEMBER_ATTR="uniqueMember"
+export LDAP_REJECT_UNAUTHORIZED="true"
+```
+
+Notes:
+
+- `MONGO_OPLOG_URL` enables Meteor's oplog tailing. Without it reactivity falls
+  back to polling; it is non-fatal but slower.
+- This instance authenticates against the **med-web.com** directory on standard
+  LDAPS port 636 with `uniqueMember` group membership — different directory,
+  port, and membership attribute from the opensource app's mieweb.org cluster.
+- `LDAP_REJECT_UNAUTHORIZED=true` means the LDAPS certificate must validate. Do
+  not re-enable `NODE_TLS_REJECT_UNAUTHORIZED=0`, which would silently defeat it.
+- **`FIREBASE_SERVICE_ACCOUNT_JSON` must be this instance's own Firebase
+  project.** The value carried over from the repo template points at
+  `mieweb-auth-dev` and will not deliver push notifications to this app's users.
+
+## 4. Service
+
+```bash
+SVC_USER=actions bash scripts/setup-systemd.sh
+```
+
+`scripts/mieauth.service` is a template — the installer substitutes the service
+user, group, and home at install time, and writes a sudoers rule granting that
+user passwordless `systemctl restart mieauth` (what the CI job calls).
+
+The service cannot start until a build exists, since `WorkingDirectory` points at
+`~/Builds/current`.
+
+## 5. Deploying
+
+```mermaid
+flowchart LR
+    A[Release tagged mie-v*<br/>or manual dispatch] --> B[Self-hosted runner<br/>on mie-fwdc-auth1]
+    B --> C[meteor build --server=<br/>https://mieauth.mieweb.org]
+    C --> D[Symlink ~/Builds/current]
+    D --> E[sudo systemctl restart mieauth]
+    E --> F[HTTP health check]
+```
+
+[deploy-mieauth.yml](.github/workflows/deploy-mieauth.yml) is server-only and
+runs on either a `mie-v*` release or a manual **Run workflow** dispatch. It is
+gated so the opensource `v*` releases never touch this host.
+
+## 6. Mobile apps
+
+Both platforms use the bundle/package ID **`org.mieweb.auth`**, distinct from the
+opensource app (`com.mieweb.mieauth` on Android, `org.mieweb.opensource` on iOS)
+so the two can be installed side by side.
+
+[mobile-config.js](mobile-config.js) is left untouched in the repo — it belongs to
+the opensource app. The workflow patches it at build time:
+
+| Field        | Patched to                                |
+| ------------ | ----------------------------------------- |
+| `id`         | `org.mieweb.auth`                         |
+| `URL_SCHEME` | `miewebauth` (opensource keeps `mieauth`) |
+| `website`    | `https://mieauth.mieweb.org`              |
+| `version`    | from the `mie-v*` tag                     |
+
+The URL scheme must differ, otherwise an invite deep link is ambiguous when both
+apps are installed on one device. Deep links use the custom scheme only — there
+are no Universal Links, so no `assetlinks.json` or `apple-app-site-association`
+to host.
+
+### Required secrets
+
+Mobile jobs are skipped unless triggered by a `mie-v*` release or a dispatch with
+**include mobile** checked, so the server can be deployed before these exist.
+
+| Secret                                                                             | Purpose                                          |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `MIE_FIREBASE_SERVICES_JSON_BASE64`                                                | `google-services.json` for `org.mieweb.auth`     |
+| `MIE_FIREBASE_IOS_PLIST_BASE64`                                                    | `GoogleService-Info.plist` for `org.mieweb.auth` |
+| `MIE_ANDROID_KEYSTORE_BASE64`                                                      | Signing keystore                                 |
+| `MIE_ANDROID_KEYSTORE_PASSWORD`                                                    | Keystore password                                |
+| `MIE_ANDROID_KEY_PASSWORD`                                                         | Key password                                     |
+| `MIE_ANDROID_KEYSTORE_ALIAS`                                                       | Key alias                                        |
+| `MIE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`                                             | Play Console upload                              |
+| `MIE_IOS_DIST_CERT_P12_BASE64`                                                     | Distribution certificate                         |
+| `MIE_IOS_DIST_CERT_PASSWORD`                                                       | Certificate password                             |
+| `MIE_IOS_PROVISIONING_PROFILE_BASE64`                                              | App Store profile for `org.mieweb.auth`          |
+| `MIE_APPLE_TEAM_ID`                                                                | Apple developer team                             |
+| `MIE_APPLE_API_KEY_ID` / `MIE_APPLE_API_ISSUER_ID` / `MIE_APPLE_API_KEY_P8_BASE64` | App Store Connect API key                        |
+
+Prerequisites that cannot be automated:
+
+- A **new Firebase project** (or at least new apps registered for
+  `org.mieweb.auth`) — its service account also replaces
+  `FIREBASE_SERVICE_ACCOUNT_JSON` in `set-env.sh`.
+- A **new App Store Connect app record** and provisioning profile for
+  `org.mieweb.auth` — the existing profile only covers `org.mieweb.opensource`,
+  and the build fails fast if the profile does not match.
+- A **new Play Console listing** for `org.mieweb.auth`. The first AAB for a new
+  package must be uploaded manually before the API will accept automated uploads.
+
+## 7. Operations
+
+```bash
+sudo systemctl status mieauth
+sudo journalctl -u mieauth -f
+sudo systemctl restart mieauth
+```
+
+Re-run [scripts/server-inventory.sh](scripts/server-inventory.sh) at any time —
+it is read-only and reports toolchain, database, ports, tunnel, and service state.

--- a/scripts/build-mieauth-local.sh
+++ b/scripts/build-mieauth-local.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────
+# build-mieauth-local.sh
+# Local mobile build for the MIE instance (mieauth.mieweb.org).
+#
+# mobile-config.js and public/resources/ belong to the OPENSOURCE app and are
+# tracked in git. This script patches them, builds, and always restores them —
+# so a local MIE build can never leak into an opensource commit.
+#
+#   bash scripts/build-mieauth-local.sh android
+#   bash scripts/build-mieauth-local.sh ios
+#   bash scripts/build-mieauth-local.sh both
+#
+#   ICON=path/to/new-logo.png bash scripts/build-mieauth-local.sh both
+# ──────────────────────────────────────────────────────────
+set -euo pipefail
+
+PLATFORM="${1:-both}"
+SERVER_URL="https://mieauth.mieweb.org"
+APP_ID="org.mieweb.auth"
+URL_SCHEME="miewebauth"
+APP_NAME="MIE Auth"
+OUT_DIR="${OUT_DIR:-./mie-build}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -n "$(git status --porcelain mobile-config.js public/resources 2>/dev/null)" ]; then
+  echo "ERROR: mobile-config.js or public/resources already has uncommitted changes."
+  echo "Commit or stash them first — this script restores to HEAD when it finishes."
+  exit 1
+fi
+
+# Restore the opensource files no matter how we exit (success, failure, Ctrl-C).
+restore() {
+  echo ""
+  echo "=== Restoring opensource app files ==="
+  git checkout -- mobile-config.js public/resources 2>/dev/null || true
+  git status --short mobile-config.js public/resources
+}
+trap restore EXIT
+
+echo "=== Building ${APP_NAME} (${APP_ID}) against ${SERVER_URL} ==="
+
+if [ -n "${ICON:-}" ]; then
+  if [ ! -f "$ICON" ]; then
+    echo "ERROR: ICON file not found: ${ICON}"
+    exit 1
+  fi
+  echo "=== Regenerating icons and splash screens from ${ICON} ==="
+  python3 generate_app_resources.py "$ICON"
+else
+  echo "ℹ️  No ICON set — keeping existing artwork."
+  echo "   Re-run with: ICON=path/to/logo.png bash $0 ${PLATFORM}"
+fi
+
+echo "=== Patching mobile-config.js ==="
+node - "$APP_ID" "$URL_SCHEME" "$SERVER_URL" "$APP_NAME" <<'PATCH'
+const fs = require("fs");
+const [appId, urlScheme, serverUrl, appName] = process.argv.slice(2);
+const file = "mobile-config.js";
+let src = fs.readFileSync(file, "utf8");
+
+src = src.replace(/id:\s*['"][^'"]+['"]/, `id: "${appId}"`);
+src = src.replace(/name:\s*['"][^'"]+['"]/, `name: "${appName}"`);
+src = src.replace(/website:\s*['"][^'"]+['"]/, `website: "${serverUrl}"`);
+src = src.replace(/URL_SCHEME:\s*['"][^'"]+['"]/, `URL_SCHEME: "${urlScheme}"`);
+
+fs.writeFileSync(file, src);
+console.log(
+  src.split("\n").filter((l) => /id:|name:|website:|URL_SCHEME/.test(l)).join("\n"),
+);
+PATCH
+
+echo "=== Generating build info ==="
+node generate-build-info.js
+
+echo "=== Checking Firebase config ==="
+for f in private/android/google-services.json private/ios/GoogleService-Info.plist; do
+  if [ ! -f "$f" ]; then
+    echo "⚠️  Missing ${f}"
+    echo "   Download it from the Firebase project for ${APP_ID}."
+  elif ! grep -q "$APP_ID" "$f"; then
+    echo "⚠️  ${f} does not mention ${APP_ID} — push notifications will fail."
+  else
+    echo "  ✅ ${f}"
+  fi
+done
+
+case "$PLATFORM" in
+  android) PLATFORMS="android" ;;
+  ios)     PLATFORMS="ios" ;;
+  both)    PLATFORMS="android,ios" ;;
+  *)       echo "ERROR: platform must be android, ios, or both"; exit 1 ;;
+esac
+
+echo "=== meteor build (${PLATFORMS}) ==="
+meteor build "$OUT_DIR" \
+  --platforms "$PLATFORMS" \
+  --server="$SERVER_URL"
+
+echo ""
+echo "═══════════════════════════════════════════════════"
+echo "✅ Build output: ${OUT_DIR}"
+echo ""
+echo "  Android: open ${OUT_DIR}/android/project in Android Studio,"
+echo "           or sign the APK/AAB under ${OUT_DIR}/android/"
+echo "  iOS:     open ${OUT_DIR}/ios/project/*.xcworkspace in Xcode,"
+echo "           set the team, then Product > Archive"
+echo "═══════════════════════════════════════════════════"

--- a/scripts/mieauth.service
+++ b/scripts/mieauth.service
@@ -7,15 +7,15 @@ StartLimitBurst=3
 
 [Service]
 Type=simple
-User=aabrol
-Group=ldapusers
-WorkingDirectory=/home/aabrol/Builds/current
-ExecStart=/home/aabrol/scripts/start-mieauth.sh
+User=__USER__
+Group=__GROUP__
+WorkingDirectory=__HOME__/Builds/current
+ExecStart=__HOME__/scripts/start-mieauth.sh
 Restart=on-failure
 RestartSec=10
 
 # Environment is sourced via start-mieauth.sh wrapper
-# which calls: source /home/aabrol/scripts/set-env.sh
+# which calls: source __HOME__/scripts/set-env.sh
 # Edit ~/scripts/set-env.sh to change environment variables
 
 # Logging — stdout/stderr go to journald
@@ -27,7 +27,7 @@ SyslogIdentifier=mieauth
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
-ReadWritePaths=/home/aabrol/Builds /home/aabrol/github
+ReadWritePaths=__HOME__
 
 # Graceful shutdown
 KillMode=mixed

--- a/scripts/provision-server.sh
+++ b/scripts/provision-server.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────
+# provision-server.sh
+# Prepares a fresh Debian host to build and run MIEAuth.
+# Idempotent — safe to re-run.
+#
+# Assumes (as found on mie-fwdc-auth1):
+#   - MongoDB already installed and running
+#   - cloudflared tunnel already terminating TLS for the public hostname,
+#     so NO nginx/certbot is installed here
+#   - GitHub Actions runner already registered
+#
+# The toolchain must belong to the user the Actions runner runs as (User= in the
+# actions.runner.* unit), which is not necessarily the user holding sudo. Run as
+# the sudo-capable account and point TARGET_USER at the runner's user:
+#
+#   TARGET_USER=actions bash provision-server.sh
+# ──────────────────────────────────────────────────────────
+set -euo pipefail
+
+NODE_VERSION="20.19.6"
+NVM_VERSION="v0.40.1"
+SWAP_SIZE_GB=4
+
+section() {
+  echo ""
+  echo "════════════════════════════════════════════════════════"
+  echo "  $1"
+  echo "════════════════════════════════════════════════════════"
+}
+
+# Per-user half: nvm, Meteor, app dirs. Re-invoked as TARGET_USER further down.
+if [ "${1:-}" = "--user-setup" ]; then
+  section "3. nvm + Node ${NODE_VERSION}  (user: $(id -un), home: ${HOME})"
+  export NVM_DIR="$HOME/.nvm"
+  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+    curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash
+  fi
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh"
+
+  if ! nvm ls "$NODE_VERSION" >/dev/null 2>&1; then
+    nvm install "$NODE_VERSION"
+  fi
+  nvm alias default "$NODE_VERSION"
+  nvm use default
+  echo "✅ node $(node --version) / npm $(npm --version)"
+
+  section "4. Meteor"
+  if [ ! -d "$HOME/.meteor" ]; then
+    # The installer tries to sudo a launcher into /usr/local/bin and hangs on a
+    # password prompt for users without sudo. Neutralise it with a no-op shim —
+    # the launcher is created later by the privileged half of this script, and
+    # ~/.meteor is on PATH regardless.
+    SHIM_DIR="$(mktemp -d)"
+    printf '#!/bin/sh\nexit 0\n' > "${SHIM_DIR}/sudo"
+    chmod +x "${SHIM_DIR}/sudo"
+    curl https://install.meteor.com/ | PATH="${SHIM_DIR}:$PATH" sh
+    rm -rf "$SHIM_DIR"
+  fi
+  export PATH="$HOME/.meteor:$PATH"
+  grep -q '.meteor' "$HOME/.profile" 2>/dev/null || echo 'export PATH="$HOME/.meteor:$PATH"' >> "$HOME/.profile"
+  echo "✅ meteor $(meteor --version 2>/dev/null || echo installed)"
+
+  section "5. App directories"
+  mkdir -p "$HOME/Builds" "$HOME/scripts"
+  echo "✅ ${HOME}/Builds and ${HOME}/scripts ready"
+
+  section "6. Verification (as $(id -un))"
+  echo "  node:    $(node --version 2>/dev/null || echo MISSING)"
+  echo "  npm:     $(npm --version 2>/dev/null || echo MISSING)"
+  echo "  git:     $(git --version 2>/dev/null || echo MISSING)"
+  echo "  meteor:  $(meteor --version 2>/dev/null || echo MISSING)"
+  exit 0
+fi
+
+TARGET_USER="${TARGET_USER:-$(id -un)}"
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+
+if [ -z "$TARGET_HOME" ]; then
+  echo "ERROR: user '${TARGET_USER}' does not exist"
+  exit 1
+fi
+
+echo "Provisioning $(hostname -f 2>/dev/null || hostname)"
+echo "  invoking user: $(id -un)"
+echo "  target user:   ${TARGET_USER}  (home: ${TARGET_HOME})"
+
+section "1. APT packages"
+# meteor/npm need git + a C toolchain to compile native modules (bcrypt, etc.)
+sudo apt-get update -qq
+sudo apt-get install -y \
+  git \
+  build-essential \
+  python3 \
+  ca-certificates \
+  curl \
+  procps
+echo "✅ base packages installed"
+
+section "2. Swap"
+# LXC/Proxmox containers cannot call swapon() — swap is a host-level setting.
+CONTAINER_TYPE="$(systemd-detect-virt -c 2>/dev/null || echo none)"
+
+if sudo swapon --show 2>/dev/null | grep -q .; then
+  echo "ℹ️  swap already active:"
+  sudo swapon --show
+elif [ "$CONTAINER_TYPE" != "none" ]; then
+  echo "ℹ️  Running inside a '${CONTAINER_TYPE}' container — swap cannot be enabled here."
+  echo "   Ask the Proxmox host admin to raise this container's RAM or swap if"
+  echo "   'meteor build' is OOM-killed. The build sets a heap cap to compensate."
+  if [ -f /swapfile ]; then
+    echo "   Removing unusable /swapfile left by an earlier attempt..."
+    sudo rm -f /swapfile
+    sudo sed -i '\|^/swapfile|d' /etc/fstab
+  fi
+else
+  echo "Creating ${SWAP_SIZE_GB}G swapfile..."
+  sudo fallocate -l "${SWAP_SIZE_GB}G" /swapfile
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  if sudo swapon /swapfile; then
+    grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab > /dev/null
+    echo "✅ swap enabled"
+  else
+    echo "⚠️  swapon failed — removing the file"
+    sudo rm -f /swapfile
+  fi
+fi
+
+section "3-6. Toolchain for '${TARGET_USER}'"
+if [ "$TARGET_USER" = "$(id -un)" ]; then
+  bash "$0" --user-setup
+else
+  # Copy to a world-readable path: TARGET_USER may not be able to read $0.
+  sudo cp "$0" /tmp/provision-user-setup.sh
+  sudo chmod 755 /tmp/provision-user-setup.sh
+  sudo -u "$TARGET_USER" -H bash /tmp/provision-user-setup.sh --user-setup
+  sudo rm -f /tmp/provision-user-setup.sh
+fi
+
+section "Host summary"
+if [ -x "${TARGET_HOME}/.meteor/meteor" ] && [ ! -e /usr/local/bin/meteor ]; then
+  sudo ln -sfn "${TARGET_HOME}/.meteor/meteor" /usr/local/bin/meteor
+  echo "✅ launcher linked: /usr/local/bin/meteor"
+fi
+echo ""
+echo "-- memory + swap --"
+free -h | head -3
+echo ""
+echo "-- mongod --"
+mongod --version 2>/dev/null | head -1 || echo "  MISSING"
+
+section "7. Cloudflare tunnel (read-only check)"
+if pgrep -x cloudflared >/dev/null 2>&1; then
+  echo "✅ cloudflared is running"
+  echo ""
+  sudo -n systemctl cat cloudflared 2>/dev/null | grep -E '^ExecStart' | sed 's/^/  /' || true
+  if sudo -n test -f /etc/cloudflared/config.yml 2>/dev/null; then
+    echo ""
+    sudo -n grep -A20 'ingress' /etc/cloudflared/config.yml 2>/dev/null | sed 's/^/  /'
+  else
+    echo ""
+    echo "  No local config.yml — this is a token-managed tunnel."
+    echo "  Configure routing in the Cloudflare dashboard:"
+    echo "    Zero Trust > Networks > Tunnels > Public Hostname"
+    echo "    mieauth.mieweb.org -> HTTP localhost:3000"
+  fi
+  echo ""
+  echo "  A 502 from https://mieauth.mieweb.org means nothing is on :3000 yet."
+else
+  echo "⚠️  cloudflared not running — the public hostname will not resolve to this box"
+fi
+
+section "Next steps"
+cat <<STEPS
+  1. Create ${TARGET_HOME}/scripts/set-env.sh (copy from the old prod host, then edit):
+       export ROOT_URL='https://mieauth.mieweb.org'
+       export APP_URL='https://mieauth.mieweb.org'
+       export PORT=3000
+       export MAIL_URL='smtp://localhost:25'
+       export MONGO_URL='mongodb://mieauth:<PASSWORD>@mie-fwdc-auth1.med-web.com:27017/mieauth?replicaSet=mieauth-rs&authSource=admin'
+       export MONGO_OPLOG_URL='mongodb://mieauth:<PASSWORD>@mie-fwdc-auth1.med-web.com:27017/local?replicaSet=mieauth-rs&authSource=admin'
+     Then:
+       sudo chown ${TARGET_USER} ${TARGET_HOME}/scripts/set-env.sh
+       sudo chmod 600 ${TARGET_HOME}/scripts/set-env.sh
+
+  2. Restore the database (old db 'mieweb_auth' -> new db 'mieauth'):
+       mongorestore --uri="\${MONGO_URL}" --archive=/tmp/mieauth.archive --gzip \\
+         --nsFrom='mieweb_auth.*' --nsTo='mieauth.*' --drop
+
+  3. Install the service (from a repo checkout, as a sudo-capable user):
+       SVC_USER=${TARGET_USER} bash scripts/setup-systemd.sh
+
+  4. Trigger the production workflow to populate ${TARGET_HOME}/Builds/current.
+STEPS

--- a/scripts/server-inventory.sh
+++ b/scripts/server-inventory.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────
+# server-inventory.sh
+# READ-ONLY audit of a host being prepared to run MIEAuth.
+# Changes nothing — safe to run on prod. Run as the service/runner user.
+#
+#   bash server-inventory.sh            # print to stdout
+#   bash server-inventory.sh > out.txt  # capture for review
+# ──────────────────────────────────────────────────────────
+
+section() {
+  echo ""
+  echo "════════════════════════════════════════════════════════"
+  echo "  $1"
+  echo "════════════════════════════════════════════════════════"
+}
+
+# Reports "installed <version>" or "MISSING" without failing the script.
+have() {
+  if command -v "$1" >/dev/null 2>&1; then
+    echo "  [ok]      $1 -> $(command -v "$1")"
+    return 0
+  fi
+  echo "  [MISSING] $1"
+  return 1
+}
+
+echo "MIEAuth server inventory — $(date)"
+
+section "1. Host / OS"
+hostname -f 2>/dev/null || hostname
+echo "IPs: $(hostname -I 2>/dev/null)"
+cat /etc/os-release 2>/dev/null | grep -E '^(PRETTY_NAME|VERSION_ID)='
+echo "Kernel: $(uname -r)"
+echo "Arch:   $(uname -m)"
+echo "Uptime: $(uptime -p 2>/dev/null)"
+echo "CPUs:   $(nproc 2>/dev/null)"
+free -h 2>/dev/null | head -2
+
+section "2. Identity / permissions"
+echo "whoami: $(whoami)"
+id
+echo "HOME:   $HOME"
+echo ""
+echo "-- passwordless sudo available? --"
+if sudo -n true 2>/dev/null; then
+  echo "  yes"
+else
+  echo "  no (or requires password) — CI needs NOPASSWD for systemctl mieauth"
+fi
+echo ""
+echo "-- sudoers drop-ins --"
+sudo -n ls -l /etc/sudoers.d/ 2>/dev/null || echo "  (cannot read without password)"
+
+section "3. Disk"
+df -h / /home 2>/dev/null
+echo ""
+echo "-- home usage --"
+du -sh "$HOME" 2>/dev/null
+
+section "4. Required toolchain"
+have node   && echo "            version: $(node --version 2>/dev/null)"
+have npm    && echo "            version: $(npm --version 2>/dev/null)"
+have meteor && echo "            version: $(meteor --version 2>/dev/null)"
+have git    && echo "            version: $(git --version 2>/dev/null)"
+have curl
+have mongod && echo "            version: $(mongod --version 2>/dev/null | head -1)"
+have mongosh
+have mongodump
+have mongorestore
+have nginx  && echo "            version: $(nginx -v 2>&1)"
+have jarsigner
+have python3
+
+echo ""
+echo "-- nvm --"
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  echo "  [ok]      ~/.nvm present"
+  ls "$HOME/.nvm/versions/node" 2>/dev/null | sed 's/^/            node: /'
+else
+  echo "  [MISSING] ~/.nvm"
+fi
+
+echo ""
+echo "-- meteor install dir --"
+[ -d "$HOME/.meteor" ] && echo "  [ok]      ~/.meteor present" || echo "  [MISSING] ~/.meteor"
+
+section "5. MIEAuth app layout"
+for p in "$HOME/Builds" "$HOME/Builds/current" "$HOME/scripts" "$HOME/scripts/set-env.sh" "$HOME/scripts/start-mieauth.sh" "$HOME/github/mieweb_auth_app"; do
+  if [ -e "$p" ]; then
+    echo "  [ok]      $p"
+  else
+    echo "  [MISSING] $p"
+  fi
+done
+echo ""
+echo "-- existing builds --"
+ls -dt "$HOME"/Builds/Webserver-build-* 2>/dev/null | head -5 || echo "  none"
+echo ""
+echo "-- current symlink --"
+readlink -f "$HOME/Builds/current" 2>/dev/null || echo "  none"
+
+echo ""
+echo "-- set-env.sh variables (values redacted) --"
+if [ -r "$HOME/scripts/set-env.sh" ]; then
+  grep -oE '^[[:space:]]*export[[:space:]]+[A-Z_]+' "$HOME/scripts/set-env.sh" | awk '{print "            " $2}'
+else
+  echo "  not present / not readable"
+fi
+
+section "6. systemd service"
+if systemctl list-unit-files 2>/dev/null | grep -q '^mieauth.service'; then
+  systemctl status mieauth --no-pager 2>/dev/null | head -15
+  echo ""
+  echo "-- enabled at boot? --"
+  systemctl is-enabled mieauth 2>/dev/null
+else
+  echo "  mieauth.service NOT installed"
+fi
+echo ""
+echo "-- any stray node processes --"
+pgrep -af "node .*main.js" 2>/dev/null || echo "  none"
+
+section "7. MongoDB"
+if systemctl list-unit-files 2>/dev/null | grep -qE '^mongod'; then
+  systemctl is-active mongod 2>/dev/null | sed 's/^/  mongod active: /'
+else
+  echo "  mongod unit not found"
+fi
+if command -v mongosh >/dev/null 2>&1; then
+  echo ""
+  echo "-- databases --"
+  mongosh --quiet --eval 'db.adminCommand("listDatabases").databases.forEach(d => print("  " + d.name + "  " + (d.sizeOnDisk/1048576).toFixed(1) + " MB"))' 2>/dev/null \
+    || echo "  cannot connect to mongodb://localhost:27017"
+  echo ""
+  echo "-- mieauth collection counts --"
+  mongosh mieauth --quiet --eval 'db.getCollectionNames().forEach(c => print("  " + c + ": " + db[c].countDocuments()))' 2>/dev/null \
+    || echo "  database not present (or requires authentication)"
+fi
+
+section "8. Listening ports"
+if command -v ss >/dev/null 2>&1; then
+  sudo -n ss -tlnp 2>/dev/null || ss -tln
+else
+  netstat -tln 2>/dev/null
+fi
+echo ""
+echo "-- is port 3000 in use? --"
+(ss -tln 2>/dev/null | grep -q ':3000 ' && echo "  YES") || echo "  no"
+
+section "9. Reverse proxy / TLS"
+for d in /etc/nginx/sites-enabled /etc/nginx/conf.d /etc/apache2/sites-enabled /etc/httpd/conf.d; do
+  [ -d "$d" ] && { echo "  $d:"; ls -1 "$d" 2>/dev/null | sed 's/^/    /'; }
+done
+echo ""
+echo "-- configs mentioning mieauth.mieweb.org or port 3000 --"
+sudo -n grep -rl -E 'mieauth\.mieweb\.org|127\.0\.0\.1:3000|localhost:3000' /etc/nginx /etc/apache2 /etc/httpd 2>/dev/null | sed 's/^/    /' || echo "    (none found or unreadable)"
+echo ""
+echo "-- certbot certificates --"
+sudo -n certbot certificates 2>/dev/null | grep -E 'Certificate Name|Domains|Expiry' || echo "  certbot not available / no certs"
+
+section "10. GitHub Actions runner"
+RUNNER_DIR=$(find "$HOME" /opt /srv -maxdepth 3 -name "svc.sh" -path "*runner*" 2>/dev/null | head -1)
+if [ -n "$RUNNER_DIR" ]; then
+  echo "  found: $RUNNER_DIR"
+  cat "$(dirname "$RUNNER_DIR")/.runner" 2>/dev/null | sed 's/^/    /'
+else
+  echo "  runner install dir not found under \$HOME, /opt, /srv"
+fi
+echo ""
+echo "-- runner services --"
+systemctl list-units --type=service --no-pager 2>/dev/null | grep -i 'actions.runner' || echo "  none registered"
+
+section "11. LDAP / SSSD"
+if [ -r /etc/sssd/sssd.conf ]; then
+  sudo -n grep -E '^(ldap_uri|ldap_user_search_base|ldap_group_search_base|ldap_default_bind_dn)' /etc/sssd/sssd.conf 2>/dev/null | sed 's/^/  /' \
+    || echo "  present but unreadable without sudo"
+else
+  echo "  /etc/sssd/sssd.conf not present"
+fi
+echo ""
+echo "-- name lookup for current user --"
+getent passwd "$(whoami)" | sed 's/^/  /'
+
+section "12. Firewall"
+sudo -n ufw status 2>/dev/null \
+  || sudo -n firewall-cmd --list-all 2>/dev/null \
+  || echo "  ufw/firewalld not available (or needs password)"
+
+section "13. Outbound connectivity"
+for target in \
+  "https://mieauth.mieweb.org" \
+  "https://fcm.googleapis.com" \
+  "https://install.meteor.com" \
+  "https://github.com"; do
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 8 "$target" 2>/dev/null || echo "000")
+  echo "  $target -> HTTP $CODE"
+done
+echo ""
+echo "-- smtp relay --"
+(timeout 5 bash -c "cat < /dev/null > /dev/tcp/relay.cluster.mieweb.org/25" 2>/dev/null && echo "  relay.cluster.mieweb.org:25 reachable") || echo "  relay.cluster.mieweb.org:25 NOT reachable"
+echo ""
+echo "-- DNS for mieauth.mieweb.org --"
+getent hosts mieauth.mieweb.org 2>/dev/null | sed 's/^/  /' || echo "  does not resolve"
+
+section "Done"
+echo "Review the [MISSING] entries above before running scripts/setup-systemd.sh."

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # ──────────────────────────────────────────────────────────
 # setup-systemd.sh
-# One-time setup script to install the MIEAuth systemd service
-# Run this on the Proxmox container: mieauth-prod.os.mieweb.org
+# One-time setup script to install the MIEAuth systemd service.
+# Run on the production host as a sudo-capable user.
+#
+# The service must run as the same user as the GitHub Actions runner, since the
+# runner owns ~/Builds. Override when they differ:
+#
+#   SVC_USER=actions bash setup-systemd.sh
 # ──────────────────────────────────────────────────────────
 set -e
 
@@ -10,30 +15,48 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SERVICE_FILE="${SCRIPT_DIR}/mieauth.service"
 START_SCRIPT="${SCRIPT_DIR}/start-mieauth.sh"
 
-echo "=== MIEAuth systemd Setup ==="
+SVC_USER="${SVC_USER:-$(id -un)}"
+SVC_GROUP="${SVC_GROUP:-$(id -gn "$SVC_USER")}"
+SVC_HOME="$(getent passwd "$SVC_USER" | cut -d: -f6)"
 
-# Step 1: Copy start wrapper script to ~/scripts
+if [ -z "$SVC_HOME" ]; then
+  echo "ERROR: user '${SVC_USER}' does not exist"
+  exit 1
+fi
+
+echo "=== MIEAuth systemd Setup ==="
+echo "Service user:  ${SVC_USER}"
+echo "Service group: ${SVC_GROUP}"
+echo "Service home:  ${SVC_HOME}"
+
+sudo -u "$SVC_USER" mkdir -p "${SVC_HOME}/scripts" "${SVC_HOME}/Builds"
+
+# Step 1: Copy start wrapper script into the service user's ~/scripts
 echo "Installing start script..."
-cp "$START_SCRIPT" "$HOME/scripts/start-mieauth.sh"
-chmod +x "$HOME/scripts/start-mieauth.sh"
-echo "✅ Start script installed: ~/scripts/start-mieauth.sh"
+sudo cp "$START_SCRIPT" "${SVC_HOME}/scripts/start-mieauth.sh"
+sudo chown "${SVC_USER}:${SVC_GROUP}" "${SVC_HOME}/scripts/start-mieauth.sh"
+sudo chmod +x "${SVC_HOME}/scripts/start-mieauth.sh"
+echo "✅ Start script installed: ${SVC_HOME}/scripts/start-mieauth.sh"
 
 # Verify set-env.sh exists (used by start script)
-if [ ! -f "$HOME/scripts/set-env.sh" ]; then
-  echo "⚠️  ~/scripts/set-env.sh not found!"
+if ! sudo test -f "${SVC_HOME}/scripts/set-env.sh"; then
+  echo "⚠️  ${SVC_HOME}/scripts/set-env.sh not found!"
   echo "   The start script sources this file for environment variables."
   echo "   Please create it before starting the service."
 fi
 
 # Step 2: Install systemd unit file
 echo "Installing systemd service..."
-sudo cp "$SERVICE_FILE" /etc/systemd/system/mieauth.service
+sed -e "s|__USER__|${SVC_USER}|g" \
+    -e "s|__GROUP__|${SVC_GROUP}|g" \
+    -e "s|__HOME__|${SVC_HOME}|g" \
+    "$SERVICE_FILE" | sudo tee /etc/systemd/system/mieauth.service > /dev/null
 sudo systemctl daemon-reload
 sudo systemctl enable mieauth
 echo "✅ systemd service installed and enabled"
 
 # Step 3: Configure sudoers for CI/CD (passwordless restart)
-SUDOERS_LINE="aabrol ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart mieauth, /usr/bin/systemctl stop mieauth, /usr/bin/systemctl start mieauth, /usr/bin/systemctl status mieauth, /usr/bin/systemctl is-active mieauth, /usr/bin/journalctl -u mieauth *"
+SUDOERS_LINE="${SVC_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart mieauth, /usr/bin/systemctl stop mieauth, /usr/bin/systemctl start mieauth, /usr/bin/systemctl status mieauth, /usr/bin/systemctl is-active mieauth, /usr/bin/journalctl -u mieauth *"
 SUDOERS_FILE="/etc/sudoers.d/mieauth"
 
 if [ ! -f "$SUDOERS_FILE" ]; then
@@ -46,12 +69,14 @@ else
 fi
 
 # Step 4: Create initial symlink if a build exists
-LATEST_BUILD=$(ls -dt ~/Builds/Webserver-build-* 2>/dev/null | head -1)
-if [ -n "$LATEST_BUILD" ] && [ -d "${LATEST_BUILD}/bundle" ]; then
-  ln -sfn "${LATEST_BUILD}/bundle" ~/Builds/current
-  echo "✅ Symlink created: ~/Builds/current → ${LATEST_BUILD}/bundle"
+HAVE_BUILD=false
+LATEST_BUILD=$(sudo ls -dt "${SVC_HOME}"/Builds/Webserver-build-* 2>/dev/null | head -1)
+if [ -n "$LATEST_BUILD" ] && sudo test -d "${LATEST_BUILD}/bundle"; then
+  sudo -u "$SVC_USER" ln -sfn "${LATEST_BUILD}/bundle" "${SVC_HOME}/Builds/current"
+  echo "✅ Symlink created: ${SVC_HOME}/Builds/current → ${LATEST_BUILD}/bundle"
+  HAVE_BUILD=true
 else
-  echo "⚠️  No existing build found. Run a deployment to create ~/Builds/current"
+  echo "⚠️  No existing build found."
 fi
 
 # Step 5: Stop nohup process if running
@@ -62,7 +87,21 @@ if pgrep -f "node main.js" > /dev/null; then
   echo "✅ Old nohup process stopped"
 fi
 
-# Step 6: Start service
+# Step 6: Start service — only meaningful once a build exists, since
+# WorkingDirectory points at the build symlink.
+if [ "$HAVE_BUILD" != true ]; then
+  echo ""
+  echo "═══════════════════════════════════════════════════"
+  echo "✅ Service installed and enabled, but not started."
+  echo ""
+  echo "  ${SVC_HOME}/Builds/current does not exist yet, so there is"
+  echo "  nothing to run. Deploy a build (tag a v* release, or run the"
+  echo "  production workflow), which creates the symlink and starts the"
+  echo "  service automatically."
+  echo "═══════════════════════════════════════════════════"
+  exit 0
+fi
+
 echo "Starting mieauth service..."
 sudo systemctl start mieauth
 sleep 5

--- a/scripts/start-mieauth.sh
+++ b/scripts/start-mieauth.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Wrapper script for systemd to start MIEAuth with proper environment
-# This sources the original set-env.sh which handles multi-line JSON properly
-source /home/aabrol/scripts/set-env.sh
-exec /home/aabrol/.nvm/versions/node/v20.19.6/bin/node main.js
+# Wrapper script for systemd to start MIEAuth with proper environment.
+# set-env.sh is sourced rather than used as an EnvironmentFile because it
+# contains multi-line JSON that systemd cannot parse.
+source "$HOME/scripts/set-env.sh"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+exec node main.js


### PR DESCRIPTION
## Summary

Stands up a second, independent MIEAuth instance at `https://mieauth.mieweb.org` on the `mie-fwdc-auth1` host, with its own database, user base, and app identity.

**The opensource app is unaffected.** `deploy-production.yml`, `mobile-config.js`, and `README.md` are untouched; that app keeps deploying to `mieauth-prod.os.mieweb.org` on `v*` tags.

| | Opensource app | MIE instance |
|---|---|---|
| URL | `mieauth-prod.os.mieweb.org` | `mieauth.mieweb.org` |
| Workflow | `deploy-production.yml` (unchanged) | `deploy-mieauth.yml` (new) |
| Release tag | `v*` | `mie-v*` |
| Deploy method | SSH to Proxmox | Local build on self-hosted runner |
| App ID | `com.mieweb.mieauth` / `org.mieweb.opensource` | `org.mieweb.auth` |
| URL scheme | `mieauth` | `miewebauth` |
| Database | `mieweb_auth` | `mieauth` (replica set, authenticated) |
| LDAP | `cluster.mieweb.org` | `ldap.med-web.com` |

## What's here

- **`.github/workflows/deploy-mieauth.yml`** — server, Android, and iOS jobs. The server job runs on the self-hosted runner that lives on the target host, so there are no SSH keys or deploy secrets. Triggered by `mie-v*` releases or manual dispatch; mobile jobs are opt-in via a dispatch input so the server can ship before signing secrets exist.
- **`scripts/server-inventory.sh`** — read-only host audit (toolchain, database, ports, ingress, runner).
- **`scripts/provision-server.sh`** — idempotent provisioner. Handles the split between the sudo-capable user and the runner's user, which are different on this host.
- **`scripts/build-mieauth-local.sh`** — local mobile build. Patches `mobile-config.js` and `public/resources` for the MIE app, then restores them on exit (including on failure) so opensource files never leak into a commit.
- **`docs/MIEAUTH_INSTANCE.md`** — setup and operations runbook.

## Changes to shared scripts

`scripts/mieauth.service` becomes a template with `__USER__` / `__GROUP__` / `__HOME__` placeholders, rendered by `setup-systemd.sh` at install time, which also derives the sudoers rule from the resolved user. Previously these were hardcoded to `aabrol:ldapusers` and would not start on the new host. `start-mieauth.sh` now sources nvm rather than a pinned node binary path. Both remain compatible with the existing host.

## Notes for review

- The URL scheme differs deliberately. Both apps registering `mieauth://` would make invite deep links ambiguous when both are installed on one device.
- Mobile jobs require new `MIE_*` secrets, plus a Firebase project, App Store Connect record, and Play Console listing for `org.mieweb.auth`. Listed in the runbook.

## Testing

- Provisioning, systemd install, and env setup have been run end to end on `mie-fwdc-auth1`.
- Workflow YAML validated; shell scripts pass `bash -n`.
- Server deploy has not run yet — it needs this workflow on the default branch before `workflow_dispatch` is available.
