### PR TITLE
fix: cover all systemctl flag forms in the mieauth sudoers rule

### DIFF
--- a/docs/MIEAUTH_INSTANCE.md
+++ b/docs/MIEAUTH_INSTANCE.md
@@ -72,8 +72,6 @@ export LDAP_URL="ldaps://ldap.med-web.com:636"
 export LDAP_BASE_DN="dc=med-web,dc=com"
 export LDAP_USER_BASE_DN="ou=people,dc=med-web,dc=com"
 export LDAP_USER_RDN_ATTR="uid"
-export LDAP_BIND_DN="uid=proxyuser,dc=med-web,dc=com"
-export LDAP_BIND_PASSWORD="<LDAP_BIND_PASSWORD>"
 export LDAP_ADMIN_GROUP_DN="cn=mie,ou=secgroup,dc=med-web,dc=com"
 export LDAP_GROUP_MEMBER_ATTR="uniqueMember"
 export LDAP_REJECT_UNAUTHORIZED="true"
@@ -86,6 +84,10 @@ Notes:
 - This instance authenticates against the **med-web.com** directory on standard
   LDAPS port 636 with `uniqueMember` group membership — different directory,
   port, and membership attribute from the opensource app's mieweb.org cluster.
+- No `LDAP_BIND_DN` / `LDAP_BIND_PASSWORD` is set, so the admin-group lookup uses
+  an **anonymous search** ([server/adminAuth.js](../server/adminAuth.js#L514)).
+  If the directory ever refuses anonymous searches, logins fail as
+  `NOT_IN_GROUP` and a service-account bind would need to be added.
 - `LDAP_REJECT_UNAUTHORIZED=true` means the LDAPS certificate must validate. Do
   not re-enable `NODE_TLS_REJECT_UNAUTHORIZED=0`, which would silently defeat it.
 - **`FIREBASE_SERVICE_ACCOUNT_JSON` must be this instance's own Firebase

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -56,16 +56,18 @@ sudo systemctl enable mieauth
 echo "✅ systemd service installed and enabled"
 
 # Step 3: Configure sudoers for CI/CD (passwordless restart)
-SUDOERS_LINE="${SVC_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart mieauth, /usr/bin/systemctl stop mieauth, /usr/bin/systemctl start mieauth, /usr/bin/systemctl status mieauth, /usr/bin/systemctl is-active mieauth, /usr/bin/journalctl -u mieauth *"
+# sudo matches arguments exactly, so every flag combination the deploy uses must
+# be listed — "is-active mieauth" does NOT cover "is-active --quiet mieauth".
+SUDOERS_LINE="${SVC_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart mieauth, /usr/bin/systemctl start mieauth, /usr/bin/systemctl stop mieauth, /usr/bin/systemctl status mieauth, /usr/bin/systemctl status mieauth --no-pager, /usr/bin/systemctl is-active mieauth, /usr/bin/systemctl is-active --quiet mieauth, /usr/bin/journalctl -u mieauth *"
 SUDOERS_FILE="/etc/sudoers.d/mieauth"
 
-if [ ! -f "$SUDOERS_FILE" ]; then
+if [ ! -f "$SUDOERS_FILE" ] || ! sudo grep -qF "is-active --quiet mieauth" "$SUDOERS_FILE"; then
   echo "$SUDOERS_LINE" | sudo tee "$SUDOERS_FILE" > /dev/null
   sudo chmod 440 "$SUDOERS_FILE"
   sudo visudo -cf "$SUDOERS_FILE"
   echo "✅ sudoers configured for passwordless systemctl"
 else
-  echo "ℹ️  Sudoers file already exists: ${SUDOERS_FILE}"
+  echo "ℹ️  Sudoers file already up to date: ${SUDOERS_FILE}"
 fi
 
 # Step 4: Create initial symlink if a build exists

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -81,8 +81,12 @@ else
   echo "⚠️  No existing build found."
 fi
 
-# Step 5: Stop nohup process if running
-if pgrep -f "node main.js" > /dev/null; then
+# Step 5: Stop a pre-systemd nohup process if one is running.
+# Skipped when the unit is already active, otherwise this kills the very
+# service we are installing — the systemd process also matches "node main.js".
+if sudo systemctl is-active --quiet mieauth; then
+  echo "ℹ️  mieauth is already managed by systemd — leaving it running"
+elif pgrep -f "node main.js" > /dev/null; then
   echo "Stopping existing nohup node process..."
   pkill -f "node main.js" || true
   sleep 3


### PR DESCRIPTION
## Problem

The first MIE instance deploy failed at the health check:

```
=== Restarting service ===
=== Health check ===
sudo: a terminal is required to read the password
sudo: a password is required
Server failed to start
```

The server itself was fine — the journal shows a clean startup (`Environment variables are set.`, Duo layers mounted, indexes created). The `CHDIR` errors in that log are from an earlier run, before any build existed.

The real cause is that **sudoers matches arguments exactly**. The workflow runs:

- `sudo systemctl is-active --quiet mieauth`
- `sudo systemctl status mieauth --no-pager`

but the rule only registered `is-active mieauth` and `status mieauth`. Neither call matched, so sudo prompted for a password that CI cannot supply, and the step aborted despite a healthy service.

## Fix

- List every flag combination the deploy actually uses.
- Rewrite an existing `/etc/sudoers.d/mieauth` when it predates this change, instead of skipping because the file exists. Without this, re-running `setup-systemd.sh` on the host would leave the broken rule in place.

## Also

Drops `LDAP_BIND_DN` / `LDAP_BIND_PASSWORD` from the runbook. They are optional — with neither set, the admin group lookup uses an anonymous search ([`server/adminAuth.js`](../blob/development/server/adminAuth.js)), which is how the existing instance already works. Documents the one failure mode: if the directory refuses anonymous searches, logins fail as `NOT_IN_GROUP`.

## Applying to the host

The sudoers file on `mie-fwdc-auth1` still has the old rule, so it must be re-run there once merged:

```bash
SVC_USER=actions bash scripts/setup-systemd.sh
```

## Testing

- `bash -n scripts/setup-systemd.sh` passes.
- The rule is validated by `visudo -cf` inside the script before it takes effect.
