### PR TITLE
fix(ci): install Pillow before generating app icons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,10 @@ jobs:
       - name: Setup Meteor/Cordova environment
         uses: mieweb/actions/prepare-meteor-cordova-env@v2.3.0
 
+      # generate_app_resources.py builds the icon set; the runner image has no Pillow.
+      - name: Install icon generator dependencies
+        run: pip3 install --break-system-packages --quiet Pillow
+
       - name: Apply release variant
         env:
           APP_VERSION: ${{ needs.select-target.outputs.app_version }}
@@ -322,6 +326,10 @@ jobs:
         uses: mieweb/actions/prepare-android-env@v2.3.0
         with:
           android_api_level: ${{ env.ANDROID_API_LEVEL }}
+
+      # generate_app_resources.py builds the icon set; the runner image has no Pillow.
+      - name: Install icon generator dependencies
+        run: pip3 install --break-system-packages --quiet Pillow
 
       - name: Apply release variant
         env:

--- a/scripts/apply-variant.sh
+++ b/scripts/apply-variant.sh
@@ -50,6 +50,11 @@ if [ -n "${BRANDING_LOGO:-}" ]; then
   esac
 
   if [ -z "$(ls -A "$BRANDING_DIR" 2>/dev/null)" ]; then
+    if ! python3 -c "import PIL" 2>/dev/null; then
+      echo "ERROR: generate_app_resources.py needs Pillow, which is not installed."
+      echo "       Install it with: pip3 install --break-system-packages Pillow"
+      exit 1
+    fi
     echo "Generating resources from ${BRANDING_LOGO}"
     mkdir -p "$BRANDING_DIR"
     python3 generate_app_resources.py "$BRANDING_LOGO" "$BRANDING_DIR"


### PR DESCRIPTION
The first `mie-os-dev` Android run through `release.yml` failed at **Apply release variant** with:

```
ModuleNotFoundError: No module named 'PIL'
```

`generate_app_resources.py` imports PIL, and neither the ubuntu nor the macos runner image ships Pillow. The old workflows pip-installed it inline immediately before calling the generator; that step was lost when the icon logic moved into `apply-variant.sh`.

This only surfaced now because the previous fix restored per-target icon generation for `mie-os-dev` — before that, no CI run ever invoked the generator.

## Changes

- Both mobile jobs install Pillow before the variant step.
- `apply-variant.sh` checks for the module first and prints the install command, so a local run fails with an instruction rather than a traceback.

## Verification

- Guard tested with a stubbed `python3` that fails `import PIL` \u2014 produces the intended error, no traceback.
- Real run still generates the icon set and restores cleanly.
- `actionlint` and YAML parse clean (one pre-existing info-level SC2012).