### PR TITLE
fix(release): patch the app id per platform, not per target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Apply release variant
         env:
           APP_VERSION: ${{ needs.select-target.outputs.app_version }}
-        run: bash scripts/apply-variant.sh "${{ needs.select-target.outputs.target }}"
+        run: bash scripts/apply-variant.sh "${{ needs.select-target.outputs.target }}" ios
 
       - name: Write Firebase config
         env:
@@ -334,7 +334,7 @@ jobs:
       - name: Apply release variant
         env:
           APP_VERSION: ${{ needs.select-target.outputs.app_version }}
-        run: bash scripts/apply-variant.sh "${{ needs.select-target.outputs.target }}"
+        run: bash scripts/apply-variant.sh "${{ needs.select-target.outputs.target }}" android
 
       - name: Write Firebase config
         env:

--- a/scripts/apply-variant.sh
+++ b/scripts/apply-variant.sh
@@ -1,22 +1,24 @@
 #!/bin/bash
 # ──────────────────────────────────────────────────────────
-# apply-variant.sh <target>
+# apply-variant.sh <target> [platform]
 # Rebrands the checked-out opensource app as one release target, using the
 # identity in variants/<target>.env.
 #
 # Used in two places:
-#   - CI: passed as `pre_build_script` to mieweb/actions
+#   - CI: run before the Meteor/Cordova build in each mobile job
 #   - Local: called by scripts/build-mobile-local.sh
 #
 # Edits mobile-config.js, public/resources and public/logo.png IN PLACE. All
 # belong to the opensource app, so callers are responsible for restoring them
 # (the local script does; CI runs on a throwaway checkout).
 #
-#   APP_VERSION=1.2.3 bash scripts/apply-variant.sh mie
+#   APP_VERSION=1.2.3 bash scripts/apply-variant.sh mie android
 #
-# mobile-config.js carries a single app id, so it is set to IOS_APP_ID. Where a
-# target's Android id differs, the Android build overrides it downstream
-# (mieweb/actions `android_app_identifier`).
+# mobile-config.js carries a SINGLE app id that Cordova uses for whichever
+# platform it is building, so the id must be chosen per platform. mie-os-prod
+# is the only target where the two differ (com.mieweb.mieauth on Play,
+# org.mieweb.opensource on the App Store); building it without a platform
+# argument produces an AAB that Play rejects as "wrong package name".
 # ──────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -24,10 +26,27 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/variant.sh"
 
 load_variant "${1:-}"
+PLATFORM="${2:-both}"
+
+case "$PLATFORM" in
+  android) APP_ID="$ANDROID_APP_ID" ;;
+  ios)     APP_ID="$IOS_APP_ID" ;;
+  both)
+    APP_ID="$IOS_APP_ID"
+    if [ "$ANDROID_APP_ID" != "$IOS_APP_ID" ]; then
+      echo "ERROR: ${TARGET} uses different ids per platform:"
+      echo "         Android: ${ANDROID_APP_ID}"
+      echo "         iOS:     ${IOS_APP_ID}"
+      echo "       mobile-config.js holds only one, so pass 'android' or 'ios'."
+      exit 1
+    fi
+    ;;
+  *) echo "ERROR: platform must be android, ios, or both"; exit 1 ;;
+esac
 
 cd "$(variant_repo_root)"
 
-echo "=== ${APP_NAME} pre-build patch (${TARGET}) ==="
+echo "=== ${APP_NAME} pre-build patch (${TARGET}, ${PLATFORM}) ==="
 
 # Icons and splash screens are derived from the source logo, so they are
 # generated here rather than committed. Targets without a logo keep the
@@ -80,7 +99,7 @@ if [ -n "${BRANDING_WEB_LOGO:-}" ]; then
   echo "Applied ${BRANDING_WEB_LOGO} → public/logo.png"
 fi
 
-node - "$IOS_APP_ID" "$APP_NAME" "$URL_SCHEME" "$SERVER_URL" "${APP_VERSION:-}" <<'PATCH'
+node - "$APP_ID" "$APP_NAME" "$URL_SCHEME" "$SERVER_URL" "${APP_VERSION:-}" <<'PATCH'
 const fs = require("fs");
 const [appId, appName, urlScheme, serverUrl, appVersion] = process.argv.slice(2);
 const file = "mobile-config.js";
@@ -112,8 +131,4 @@ console.log(
 );
 PATCH
 
-if [ "$ANDROID_APP_ID" != "$IOS_APP_ID" ]; then
-  echo "Note: Android id for ${TARGET} is ${ANDROID_APP_ID}, applied by the Android build"
-fi
-
-echo "✅ Patched for ${APP_NAME} (${IOS_APP_ID}) → ${SERVER_URL}"
+echo "✅ Patched for ${APP_NAME} (${APP_ID}) → ${SERVER_URL}"

--- a/scripts/build-mobile-local.sh
+++ b/scripts/build-mobile-local.sh
@@ -53,7 +53,7 @@ restore() {
 }
 trap restore EXIT
 
-bash scripts/apply-variant.sh "$TARGET"
+bash scripts/apply-variant.sh "$TARGET" "$PLATFORM"
 
 # Cordova cannot rename an existing platform ("product name change ... is not
 # supported dynamically"), and config.xml gets rewritten before that check, so


### PR DESCRIPTION
Fixes the Android half of the `mie-os-prod-v1.6.2` release failure ([run 32509502904](https://github.com/mieweb/mieweb_auth_app/actions/runs/32509502904)):

```
[!] Google Api Error: Invalid request - APK has the wrong package name.
```

## Root cause

`mie-os-prod` is the **only** target whose Android and iOS ids differ:

| Target | Android | iOS |
|---|---|---|
| `mie-os-dev` | `org.mieweb.os.dev` | `org.mieweb.os.dev` |
| `mie` | `org.mieweb.auth` | `org.mieweb.auth` |
| `mie-os-prod` | `com.mieweb.mieauth` | `org.mieweb.opensource` |

`mobile-config.js` carries a **single** `id`, and Cordova uses it for whichever platform it is building. `apply-variant.sh` always wrote `IOS_APP_ID`, then printed:

```
Note: Android id for mie-os-prod is com.mieweb.mieauth, applied by the Android build
```

Nothing applied it. That note described a step that does not exist — the AAB was built as `org.mieweb.opensource` and Play rejected it.

The deleted prod workflow did this with an inline `sed` immediately before the Android build, commented *"Android bundle ID must be `com.mieweb.mieauth` (Play Store) while mobile-config.js defaults to `org.mieweb.opensource`"*. That patch was lost when the logic moved into `apply-variant.sh`.

No earlier run caught it because the other two targets use one id for both platforms — `mie-os-prod` Android had only ever been built with `publish: false`, which stops before Play validates the package name.

## The fix

`apply-variant.sh` takes an optional platform argument and selects the matching id. `release.yml` passes `ios` from `mobile-ios` and `android` from `mobile-android`; `build-mobile-local.sh` forwards the platform it already accepts.

Omitting the platform on a target whose ids differ is now a **hard error** rather than a silently wrong build:

```
ERROR: mie-os-prod uses different ids per platform:
         Android: com.mieweb.mieauth
         iOS:     org.mieweb.opensource
       mobile-config.js holds only one, so pass 'android' or 'ios'.
```

## Verification

Ran locally against every combination:

| Invocation | Resulting `id` | |
|---|---|---|
| `mie-os-prod android` | `com.mieweb.mieauth` | fixed |
| `mie-os-prod ios` | `org.mieweb.opensource` | unchanged |
| `mie-os-prod` (no platform) | — | fails loudly |
| `mie android` | `org.mieweb.auth` | unchanged |
| `mie-os-dev ios` | `org.mieweb.os.dev` | unchanged |

`bash -n` clean on both scripts; `actionlint` clean on `release.yml` apart from the pre-existing SC2012 info.

## Not covered by this PR

The same run also failed `mobile-ios`, for an unrelated reason:

```
[!] No matching provisioning profiles found and cannot create a new one
    because you enabled `readonly`.
```

The opensource iOS app was historically signed from `IOS_DIST_CERT_P12_BASE64` / `IOS_PROVISIONING_PROFILE_BASE64`, never through `match`, so `mieweb/mobile-signing` has no `match AppStore org.mieweb.opensource` entry. That needs an out-of-band `fastlane match appstore --readonly false` run using the App Store Connect API key — the same fix already applied for `org.mieweb.auth`. Not a code change, so it is deliberately out of scope here.

## Retry

`mie-os-prod-v1.6.2` is consumed, but nothing reached either store, so `1.6.2` is still free version-wise. Retry needs a new tag (`mie-os-prod-v1.6.3`) after this merges **and** the iOS profile exists.
