### PR TITLE
fix(privacy): name the publisher and disclose collected data

### DIFF
--- a/client/web/PrivacyPolicyPage.jsx
+++ b/client/web/PrivacyPolicyPage.jsx
@@ -1,48 +1,216 @@
 import React from "react";
-import { Shield, Eye, Lock, Database, Trash2 } from "lucide-react";
+import {
+  Shield,
+  Eye,
+  Lock,
+  Database,
+  Trash2,
+  Building2,
+  Share2,
+  Ban,
+  Fingerprint,
+  Clock,
+  Mail,
+} from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Card, CardContent } from "@mieweb/ui";
 import { Layout } from "./components/Layout";
 import { usePageTitle } from "../hooks/usePageTitle";
 
+// Google Play requires the policy to name the developer and every app it
+// covers, and to list collected data consistently with the Data Safety form.
+const COMPANY = "Medical Informatics Engineering, LLC";
+
 const sections = [
+  {
+    icon: Building2,
+    title: "Who This Policy Covers",
+    color: "from-slate-500/20 to-gray-500/20",
+    iconColor: "text-slate-600 dark:text-slate-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          This Privacy Policy is issued by {COMPANY} (&ldquo;MIE&rdquo;), the
+          developer and operator of the applications and services described
+          below.
+        </p>
+        <p>It applies to the following applications:</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>
+            <span className="font-medium text-foreground">MIEAuth</span> —
+            Android package <code>com.mieweb.mieauth</code>, iOS bundle{" "}
+            <code>org.mieweb.opensource</code>
+          </li>
+          <li>
+            <span className="font-medium text-foreground">MIEAuth Beta</span> —
+            Android package and iOS bundle <code>org.mieweb.os.dev</code>
+          </li>
+          <li>
+            <span className="font-medium text-foreground">MIEWeb Auth</span> —
+            Android package and iOS bundle <code>org.mieweb.auth</code>
+          </li>
+        </ul>
+        <p>
+          It also applies to the associated websites and back-end services that
+          MIE operates for these applications.
+        </p>
+      </div>
+    ),
+  },
   {
     icon: Eye,
     title: "Overview",
     color: "from-blue-500/20 to-cyan-500/20",
     iconColor: "text-blue-600 dark:text-blue-400",
     content: (
-      <p className="text-muted-foreground">
-        We safeguard user privacy while maintaining the ability to identify
-        individuals who use our Services. We do not support anonymous use of our
-        systems.
-      </p>
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          These applications provide multi-factor authentication. MIE safeguards
+          user privacy while maintaining the ability to identify individuals who
+          use the Services, because verifying identity is the purpose of the
+          product. MIE does not support anonymous use of these systems.
+        </p>
+        <p>
+          MIE does not sell personal information, does not share it with data
+          brokers, and does not use it for advertising or for any form of
+          behavioural profiling.
+        </p>
+      </div>
     ),
   },
   {
-    icon: Shield,
-    title: "Anonymity",
-    color: "from-purple-500/20 to-pink-500/20",
-    iconColor: "text-purple-600 dark:text-purple-400",
+    icon: Database,
+    title: "Information MIE Collects",
+    color: "from-amber-500/20 to-orange-500/20",
+    iconColor: "text-amber-600 dark:text-amber-400",
+    content: (
+      <div className="space-y-4 text-muted-foreground">
+        <div>
+          <p className="font-medium text-foreground mb-1">
+            Account information
+          </p>
+          <p>
+            First name, last name, username, and email address, provided by the
+            user or by an administrator who invites them. Passwords and PINs are
+            stored only as salted cryptographic hashes; MIE never stores them in
+            readable form.
+          </p>
+        </div>
+        <div>
+          <p className="font-medium text-foreground mb-1">Device information</p>
+          <p>
+            A device identifier, device model, operating system platform and
+            version, a user-assigned device nickname, and the registration and
+            activity timestamps for each registered device. This information
+            identifies which devices are entitled to approve a sign-in.
+          </p>
+        </div>
+        <div>
+          <p className="font-medium text-foreground mb-1">
+            Push notification tokens
+          </p>
+          <p>
+            A Firebase Cloud Messaging token for each registered device, used
+            solely to deliver authentication requests to that device.
+          </p>
+        </div>
+        <div>
+          <p className="font-medium text-foreground mb-1">
+            Authentication activity
+          </p>
+          <p>
+            A record of authentication requests and their outcome — approved,
+            rejected, or expired — together with the device that responded and
+            the time it responded. This record exists so that users and
+            administrators can review access to their accounts.
+          </p>
+        </div>
+      </div>
+    ),
+  },
+  {
+    icon: Ban,
+    title: "Information MIE Does Not Collect",
+    color: "from-teal-500/20 to-cyan-500/20",
+    iconColor: "text-teal-600 dark:text-teal-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
+        <p>These applications do not collect or request:</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Location data of any kind</li>
+          <li>Contacts, calendar entries, SMS messages, or call logs</li>
+          <li>Photos, files, or microphone audio</li>
+          <li>Advertising identifiers or analytics for advertising purposes</li>
+        </ul>
+        <p>
+          The applications request camera access on the devices where it is
+          offered, and use it for one purpose only: scanning a QR code to
+          complete an invitation. Camera frames are analysed on the device as
+          they are viewed and are never recorded, stored, or transmitted.
+        </p>
+      </div>
+    ),
+  },
+  {
+    icon: Fingerprint,
+    title: "Biometric Authentication",
+    color: "from-violet-500/20 to-purple-500/20",
+    iconColor: "text-violet-600 dark:text-violet-400",
     content: (
       <div className="space-y-3 text-muted-foreground">
         <p>
-          When you use our Services, we may take reasonable steps to determine
-          your identity or, if you are operating through an automated agent, the
-          identity of the individual controlling that agent.
+          Where a device offers fingerprint or face unlock, the applications can
+          use it to confirm that the person approving a request is the device
+          owner.
         </p>
         <p>
-          We may deny access to our Services if you or your agents engage in
-          conduct that is harmful to our interests. If your actions violate
-          applicable law (U.S. law by default, others considered as
-          appropriate), we may cooperate with authorities in accordance with the
-          Privacy and Confidentiality provisions below.
+          Biometric data never leaves the device and is never transmitted to or
+          stored by MIE. The operating system performs the match locally and
+          reports only success or failure. MIE stores a cryptographic secret
+          tied to the device, which proves possession of that device and cannot
+          be used to reconstruct any biometric information.
         </p>
+      </div>
+    ),
+  },
+  {
+    icon: Share2,
+    title: "How Information Is Shared",
+    color: "from-orange-500/20 to-red-500/20",
+    iconColor: "text-orange-600 dark:text-orange-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
         <p>
-          Deliberate efforts to obscure identity—including aliases, VPNs,
-          multiple identities, or hidden services—may be treated as misuse and
-          may result in blocking, as such behavior suggests an intent to avoid
-          accountability and creates unacceptable risk.
+          MIE does not sell personal information. It is disclosed only to the
+          service providers required to operate the product:
+        </p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>
+            <span className="font-medium text-foreground">
+              Google Firebase Cloud Messaging
+            </span>{" "}
+            — receives the device push token and the notification content in
+            order to deliver authentication requests.
+          </li>
+          <li>
+            <span className="font-medium text-foreground">
+              The email delivery provider
+            </span>{" "}
+            — receives the email address and message content for invitations,
+            approvals, and account notices.
+          </li>
+          <li>
+            <span className="font-medium text-foreground">Duo Security</span> —
+            where an organisation has enabled the optional Duo integration,
+            receives username, email, display name, and registered device
+            details so that devices appear in that organisation&rsquo;s Duo
+            administration console.
+          </li>
+        </ul>
+        <p>
+          Where an organisation deploys these applications for its members, that
+          organisation&rsquo;s administrators can see the account and device
+          information belonging to their own users.
         </p>
       </div>
     ),
@@ -53,29 +221,84 @@ const sections = [
     color: "from-green-500/20 to-emerald-500/20",
     iconColor: "text-green-600 dark:text-green-400",
     content: (
-      <p className="text-muted-foreground">
-        Once identity is established, the protection of your personal
-        information is a priority. We will not disclose data linked to your
-        identity without your direction, unless required by a valid court order
-        and subject to your opportunity to contest that order.
-      </p>
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          Once identity is established, protecting personal information is a
+          priority. MIE will not disclose data linked to a user&rsquo;s identity
+          without that user&rsquo;s direction, unless required by a valid court
+          order and subject to the user&rsquo;s opportunity to contest it.
+        </p>
+        <p>
+          Traffic between the applications and MIE servers is encrypted in
+          transit. Passwords, PINs, and access tokens are stored only as
+          cryptographic hashes.
+        </p>
+      </div>
+    ),
+  },
+  {
+    icon: Shield,
+    title: "Identity and Acceptable Use",
+    color: "from-purple-500/20 to-pink-500/20",
+    iconColor: "text-purple-600 dark:text-purple-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          When a person uses the Services, MIE may take reasonable steps to
+          determine their identity or, if they are operating through an
+          automated agent, the identity of the individual controlling that
+          agent.
+        </p>
+        <p>
+          MIE may deny access where conduct is harmful to its interests. Where
+          actions violate applicable law (U.S. law by default, others considered
+          as appropriate), MIE may cooperate with authorities in accordance with
+          the Privacy and Confidentiality provisions above.
+        </p>
+        <p>
+          Because the product exists to establish identity, deliberate efforts
+          to obscure it — including aliases, multiple identities, or hidden
+          services — may be treated as misuse and may result in access being
+          blocked.
+        </p>
+      </div>
     ),
   },
   {
     icon: Database,
     title: "Ownership of Data",
-    color: "from-amber-500/20 to-orange-500/20",
-    iconColor: "text-amber-600 dark:text-amber-400",
+    color: "from-sky-500/20 to-blue-500/20",
+    iconColor: "text-sky-600 dark:text-sky-400",
     content: (
       <div className="space-y-3 text-muted-foreground">
         <p>
-          Data you submit to our Services remains your property. We do not claim
-          ownership and will not use it without your permission.
+          Data submitted to the Services remains the property of the person who
+          submitted it. MIE does not claim ownership of it and will not use it
+          for unrelated purposes without permission.
         </p>
         <p>
-          Metadata generated through your use of our Services is owned by us and
-          is handled in accordance with the Privacy and Confidentiality
-          provisions above.
+          Metadata generated through use of the Services is owned by MIE and is
+          handled in accordance with the Privacy and Confidentiality provisions
+          above.
+        </p>
+      </div>
+    ),
+  },
+  {
+    icon: Clock,
+    title: "Data Retention",
+    color: "from-indigo-500/20 to-blue-500/20",
+    iconColor: "text-indigo-600 dark:text-indigo-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          Account and device information is retained for as long as the account
+          remains active, because it is required for the account to function.
+        </p>
+        <p>
+          Records of outgoing email are retained for 90 days with personal
+          details masked. Authentication activity is retained so that account
+          access can be reviewed, and is removed when the account is deleted.
         </p>
       </div>
     ),
@@ -88,19 +311,55 @@ const sections = [
     content: (
       <div className="space-y-3 text-muted-foreground">
         <p>
-          You have the right to request deletion of your account and associated
-          data at any time.
+          Users have the right to request deletion of their account and
+          associated data at any time.
         </p>
         <p>
-          To request account deletion, please visit our{" "}
+          To request deletion, visit the{" "}
           <a
             href="/delete-account"
             className="text-primary hover:text-primary/80 underline transition-colors"
           >
             account deletion page
           </a>
-          . Your request will be processed within 30 days, and you will receive
-          confirmation when complete.
+          . Requests are processed within 30 days and confirmation is sent when
+          complete.
+        </p>
+        <p>
+          Deleting an account removes the account record, all registered device
+          records — including device identifiers, push tokens, and the
+          device-bound cryptographic secret — and the associated authentication
+          activity.
+        </p>
+      </div>
+    ),
+  },
+  {
+    icon: Mail,
+    title: "Children and Contact",
+    color: "from-emerald-500/20 to-green-500/20",
+    iconColor: "text-emerald-600 dark:text-emerald-400",
+    content: (
+      <div className="space-y-3 text-muted-foreground">
+        <p>
+          These applications are intended for use by adults in a workplace or
+          organisational setting. They are not directed at children, and MIE
+          does not knowingly collect personal information from children.
+        </p>
+        <p>
+          MIE may update this policy from time to time; the date shown above
+          reflects the most recent revision.
+        </p>
+        <p>
+          For any question about this policy or about personal data, contact{" "}
+          {COMPANY} through the{" "}
+          <a
+            href="/support"
+            className="text-primary hover:text-primary/80 underline transition-colors"
+          >
+            support page
+          </a>
+          .
         </p>
       </div>
     ),
@@ -153,8 +412,16 @@ export const PrivacyPolicyPage = () => {
           <motion.p
             initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.15 }}
+            className="mt-4 text-base text-muted-foreground"
+          >
+            {COMPANY}
+          </motion.p>
+          <motion.p
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.2 }}
-            className="mt-4 text-sm text-muted-foreground"
+            className="mt-2 text-sm text-muted-foreground"
           >
             Last updated: {new Date().toLocaleDateString()}
           </motion.p>

--- a/client/web/components/Layout.jsx
+++ b/client/web/components/Layout.jsx
@@ -69,8 +69,8 @@ export const Layout = ({ children }) => {
       <SiteHeader
         logo={{
           src: "/logo.png",
-          alt: "MIE Auth Logo",
-          name: "MIE Auth",
+          alt: "MIEAuth Logo",
+          name: "MIEAuth",
           href: "/",
         }}
         links={links}
@@ -107,14 +107,14 @@ export const Layout = ({ children }) => {
       <SiteFooter
         logo={{
           src: "/logo.png",
-          alt: "MIE Auth Logo",
-          name: "MIE Auth",
+          alt: "MIEAuth Logo",
+          name: "MIEAuth",
           href: "/",
         }}
-        description="Secure, seamless, and privacy-focused authentication for your applications."
+        description="Secure, seamless, and privacy-focused authentication, from Medical Informatics Engineering."
         linkGroups={footerLinkGroups}
         socialLinks={socialLinks}
-        companyName="MIE Auth"
+        companyName="Medical Informatics Engineering, LLC. All Rights Reserved."
         variant="dark"
         privacyHref="/privacy-policy"
       />


### PR DESCRIPTION
Fixes the Google Play policy rejection on the privacy policy (Milestone 6).

## Why it was rejected

The policy at `/privacy-policy` failed three separate Play requirements:

1. **No developer named.** It said "we" and "our" throughout without ever identifying who that is.
2. **No apps named.** Play requires the policy to name the apps it covers.
3. **No data disclosure.** It described principles but never said what is actually collected, so nothing could be reconciled against the Data Safety form.

## Changes

**Publisher and scope.** A new opening section names **Medical Informatics Engineering, LLC** as publisher and lists all three apps by package/bundle id: `com.mieweb.mieauth` / `org.mieweb.opensource` (MIEAuth), `org.mieweb.os.dev` (MIEAuth Beta), and `org.mieweb.auth` (MIEWeb Auth). The company name also appears under the page title.

**Wording.** Every unattributed `we` / `our` / `us` is gone — the entity is defined once as "MIE" and used by name after that, so the controller is never ambiguous. Verified: zero first-person pronouns remain in the file.

**Footer.** Copyright now renders `© 2026 Medical Informatics Engineering, LLC. All Rights Reserved.` instead of the product name, and the header/footer wordmark is `MIEAuth`, matching the store listing rather than the previous inconsistent "MIE Auth".

**New sections**, written from the actual code rather than boilerplate:

| Section | Covers |
|---|---|
| Information MIE Collects | Account (name, username, email), device (id, model, platform, nickname, timestamps), FCM push tokens, authentication activity |
| Information MIE Does Not Collect | No location, contacts, calendar, SMS, call logs, photos, microphone, or ad identifiers; camera is QR-only and never recorded |
| Biometric Authentication | Biometric data never leaves the device; only a device-bound cryptographic secret is stored |
| How Information Is Shared | Firebase (push), email provider, optional Duo integration; no sale, no data brokers |
| Data Retention | Active-account retention; 90-day masked email logs |
| Account Deletion | Expanded to state exactly what is removed |
| Children and Contact | Not directed at children; contact route via support page |

Data inventory was derived from `utils/api/deviceDetails.js`, `utils/api/notificationHistory.js`, `utils/api/emailLog.js`, `server/firebase.js`, and `server/duo/adminModel.js`.

## Verification

`eslint` clean on both files (only the pre-existing unused-`React` warning). No first-person pronouns remain.

## Needs a decision before merge

**`LLC` vs `Inc.`** — this PR uses **Medical Informatics Engineering, LLC** as instructed. That does not match the signing identities already in use:

- iOS distribution certificate: `Apple Distribution: Medical Informatics Engineering, Inc.`
- Android release keystore: `O=Medical Informatics Engineering`

Play compares the stated entity against the developer account. If the registered entity is `Inc.`, this needs changing to `Inc.` before merge — please confirm which is correct.

Two smaller items also worth confirming:

- **No postal address or contact email.** Contact routes through `/support`. Play accepts this, but some reviewers prefer a direct email — say the word and I will add one.
- **The 30-day deletion window is a manual admin process**, with no automated enforcement. `NotificationHistory` and `DeviceAuditLog` are also not currently removed on account deletion, though the policy implies activity records are. Worth aligning the code with the promise in a follow-up.

## Deployment

This is a server-rendered page, so it ships with a **server deploy**, not a mobile build. Play re-review needs the policy live at the public URL first.
