### PR TITLE
chore(mobile): bump the base version to 1.7.0

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -5,7 +5,7 @@ App.info({
   author: "Anshul Abrol",
   email: "abrol.anshul10@gmail.com",
   website: "https://mieauth-prod.os.mieweb.org",
-  version: '1.6.0',
+  version: "1.7.0",
 });
 
 App.setPreference("android-targetSdkVersion", "36");


### PR DESCRIPTION
Bumps the base version in `mobile-config.js` from `1.6.0` to `1.7.0`.

## Why

Dispatch builds do not stamp a version — `APP_VERSION` is only set on a release event — so a `workflow_dispatch` run ships whatever `mobile-config.js` holds. `1.6.0` has already been uploaded to both TestFlight and Play, which is exactly why the last `publish: true` dispatch failed:

```
ERROR: [altool] The provided entity includes an attribute with a value that
has already been used (-19232) The bundle version must be higher than the
previously uploaded version: '1.6.0'.
```

`1.6.1` and `1.6.2` are also spent — `mie-os-dev-v1.6.1` published successfully, and `mie-os-prod-v1.6.2` consumed that tag — so `1.7.0` is the next clear base.

Release-event builds are unaffected either way, since they take the version from the tag.

## Scope

One line. No behaviour change to the pipeline itself.

## Related, not fixed here

This unblocks the *next* dispatch publish but does not remove the underlying trap: nothing sets `android-versionCode` or `ios-CFBundleVersion`, so any given version string can still only ever be uploaded once. The second `publish: true` dispatch after this merges will collide again on `1.7.0`.

The durable fix is stamping a monotonic build number from `github.run_number` for dispatch builds — the approach the deleted `test-ios-fastlane.yml` used via `App.setPreference('ios-CFBundleVersion', github.run_number)`. Tracked as a separate follow-up.
